### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "62daa90f6e9bc22fd65676c4343ae3e3a3062e3a9b779692d9266ec33927e7b0",
+  "originHash" : "589fe9886bf0d8355f115696294d421af99bf8e51c24ef2bc04028ed9b967f08",
   "pins" : [
     {
       "identity" : "eudi-lib-ios-iso18013-data-model",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "f4bc1007d343b51ed231a4420215b42a695d9de3",
-        "version" : "0.5.5"
+        "revision" : "dc3d6f457d22cd5275a42c562d38eb2dc5b01042",
+        "version" : "0.5.6"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "45305d32cfb830faebcaa9a7aea66ad342637518",
-        "version" : "3.11.1"
+        "revision" : "a98e4be0dd9f0377a818f2198a2bc87bbd2bfcea",
+        "version" : "3.11.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["MdocSecurity18013"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git", exact: "0.5.5"),
+        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git", exact: "0.5.6"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
         .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMajor(from: "1.0.0"))
     ],


### PR DESCRIPTION
Upgrade `eudi-lib-ios-iso18013-data-model` to version 0.5.6 and `swift-crypto` to version 3.11.2 to ensure compatibility and access to the latest features.