### PR TITLE
Refactor DeviceAuthentication and MdocAuthentication to use CBOREncodable for sessionTranscript

### DIFF
--- a/Sources/MdocSecurity18013/MdocAuthentication/DeviceAuthentication.swift
+++ b/Sources/MdocSecurity18013/MdocAuthentication/DeviceAuthentication.swift
@@ -23,9 +23,9 @@ import MdocDataModel18013
 /// This structure is not transfered, only computed
 /// The mDL calculates this ephemeral MAC by performing KDF(ECDH(mDL private key, reader ephemeral public key)) and the mDL reader calculates this ephemeral MAC by performing KDF(ECDH(mDL public key, reader ephemeral private key)).
   public struct DeviceAuthentication: Sendable {
-    let sessionTranscript: SessionTranscript
+    let sessionTranscript: CBOREncodable & Sendable
     let docType: String
-    let deviceNameSpacesRawData: [UInt8] 
+    let deviceNameSpacesRawData: [UInt8]
   }
 
   extension DeviceAuthentication: CBOREncodable {

--- a/Tests/MdocSecurity18013Tests/MdocSecurity18013Tests.swift
+++ b/Tests/MdocSecurity18013Tests/MdocSecurity18013Tests.swift
@@ -77,8 +77,8 @@ final class MdocSecurity18013Tests: XCTestCase {
         let (_,sessionEncr) = try XCTUnwrap(make_session_encryption_from_annex_data())
         var authKeys = CoseKeyExchange(publicKey: Self.AnnexdTestData.d51_ephReaderKey.key, privateKey: Self.AnnexdTestData.d53_deviceKey)
         if authKeys.privateKey.privateKeyId == nil { try await authKeys.privateKey.makeKey(curve: CoseEcCurve.P256) }
-        let mdocAuth = MdocAuthentication(transcript: sessionEncr.transcript, authKeys: authKeys)
-        let da = DeviceAuthentication(sessionTranscript: mdocAuth.transcript, docType: "org.iso.18013.5.1.mDL", deviceNameSpacesRawData: [0xA0])
+        let mdocAuth = MdocAuthentication(sessionTranscript: sessionEncr.transcript, authKeys: authKeys)
+        let da = DeviceAuthentication(sessionTranscript: mdocAuth.sessionTranscript, docType: "org.iso.18013.5.1.mDL", deviceNameSpacesRawData: [0xA0])
         XCTAssertEqual(Data(da.toCBOR(options: CBOROptions()).taggedEncoded.encode(options: CBOROptions())), AnnexdTestData.d53_deviceAuthDeviceAuthenticationBytes)
         let coseIn = Cose(type: .mac0, algorithm: Cose.MacAlgorithm.hmac256.rawValue, payloadData: AnnexdTestData.d53_deviceAuthDeviceAuthenticationBytes)
 		let dataToSign = try XCTUnwrap(coseIn.signatureStruct)
@@ -89,7 +89,7 @@ final class MdocSecurity18013Tests: XCTestCase {
         let (_,sessionEncr) = try XCTUnwrap(make_session_encryption_from_annex_data())
         var authKeys = CoseKeyExchange(publicKey: Self.AnnexdTestData.d51_ephReaderKey.key, privateKey: Self.AnnexdTestData.d53_deviceKey)
         if authKeys.privateKey.privateKeyId == nil { try await authKeys.privateKey.makeKey(curve: CoseEcCurve.P256) }
-        let mdocAuth = MdocAuthentication(transcript: sessionEncr.transcript, authKeys: authKeys)
+        let mdocAuth = MdocAuthentication(sessionTranscript: sessionEncr.transcript, authKeys: authKeys)
 		let bUseDeviceSign = UserDefaults.standard.bool(forKey: "PreferDeviceSignature")
         let dAuthO = try await mdocAuth.getDeviceAuthForTransfer(docType: "org.iso.18013.5.1.mDL", deviceNameSpacesRawData: [0xA0],
             dauthMethod: bUseDeviceSign ? .deviceSignature : .deviceMac, unlockData: nil)


### PR DESCRIPTION
Update the `DeviceAuthentication` and `MdocAuthentication` structures to utilize `CBOREncodable` for the `sessionTranscript`, enhancing flexibility in handling session data. Adjust related initializations and tests accordingly.