### PR TITLE
Update IssuerSigned validation logic by removing trusted IACA checks

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "49b6ca6a30423da527b2762721ef67222e0332bfc301f49ae4a24ccb319dcf8c",
+  "originHash" : "0b1cd5a8074a8df547fce6417b14b9436a5dfa16c3e7b101c58e6dc2d930e712",
   "pins" : [
     {
       "identity" : "eudi-lib-ios-iso18013-data-model",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "53861fb46e6cbc39e92af57346a22e29bd159ada",
-        "version" : "0.8.0"
+        "revision" : "a2b2d3af28491ef56dd8bc189be3e7e57d789819",
+        "version" : "0.8.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         // .package(path: "../eudi-lib-ios-iso18013-data-model"),
-        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git", exact: "0.8.0"),
+        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git", exact: "0.8.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
         .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMajor(from: "1.0.0")),
     ],

--- a/Tests/MdocSecurity18013Tests/MsoValidationTests.swift
+++ b/Tests/MdocSecurity18013Tests/MsoValidationTests.swift
@@ -29,7 +29,7 @@ struct MsoValidationTests {
 		let dr = try DeviceResponse(data: [UInt8](base64Data))
 		let iss = try #require(dr.documents?.first?.issuerSigned)
         do {
-            try iss.validateMSO(docType: "eu.europa.ec.eudi.pid.1", trustedIACA: [])
+            try iss.validate(docType: "eu.europa.ec.eudi.pid.1")
         } catch {
             // Expected to fail due to missing/invalid certificates in x5chain
             switch error {


### PR DESCRIPTION
Simplify the MSO validation logic by removing trusted IACA checks and update the eudi-lib-ios-iso18013-data-model dependency to version 0.8.1.