### PR TITLE
Refactor key batch creation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "0b1cd5a8074a8df547fce6417b14b9436a5dfa16c3e7b101c58e6dc2d930e712",
+  "originHash" : "6836836db3170c90e8a3124666066279025e4c0947226d83bcfa17435c9a3567",
   "pins" : [
     {
       "identity" : "eudi-lib-ios-iso18013-data-model",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "a2b2d3af28491ef56dd8bc189be3e7e57d789819",
-        "version" : "0.8.1"
+        "revision" : "395cca652e2c9884b60aae4e9b6f6a5015dc4ec7",
+        "version" : "0.9.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         // .package(path: "../eudi-lib-ios-iso18013-data-model"),
-        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git", exact: "0.8.1"),
+        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git", exact: "0.9.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
         .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMajor(from: "1.0.0")),
     ],

--- a/Sources/MdocSecurity18013/SecureAreaImplementations/SampleDataSecureArea.swift
+++ b/Sources/MdocSecurity18013/SecureAreaImplementations/SampleDataSecureArea.swift
@@ -35,7 +35,7 @@ public actor SampleDataSecureArea: SecureArea {
     public static var supportedEcCurves: [CoseEcCurve] { [.P256, .P384, .P521] }
     public func getStorage() async -> any MdocDataModel18013.SecureKeyStorage { storage }
 
-    public func createKeyBatch(id: String, keyOptions: KeyOptions?) async throws -> [CoseKey] {
+    public func createKeyBatch(id: String, credentialOptions: CredentialOptions, keyOptions: KeyOptions?) async throws -> [CoseKey] {
         let x963Priv: Data; let x963Pub: Data
         let curve = keyOptions?.curve ?? .P256
         switch curve {

--- a/Sources/MdocSecurity18013/SecureAreaImplementations/SecureEnclaveSecureArea.swift
+++ b/Sources/MdocSecurity18013/SecureAreaImplementations/SecureEnclaveSecureArea.swift
@@ -34,9 +34,9 @@ public actor SecureEnclaveSecureArea: SecureArea {
     }
     public func getStorage() async -> any MdocDataModel18013.SecureKeyStorage { storage }
 
-    public func createKeyBatch(id: String, keyOptions: KeyOptions?) async throws -> [CoseKey] {
+    public func createKeyBatch(id: String, credentialOptions: CredentialOptions, keyOptions: KeyOptions?) async throws -> [CoseKey] {
         if let keyOptions, keyOptions.curve != Self.defaultEcCurve { throw SecureAreaError("Unsupported curve \(keyOptions.curve)") }
-        let batchSize = keyOptions?.batchSize ?? 1
+        let batchSize = credentialOptions.batchSize
         var res: [CoseKey] = []; res.reserveCapacity(batchSize)
         var dicts = [[String: Data]](); dicts.reserveCapacity(batchSize)
         // create extra keys and save them as a batch with indexes from 1 to batch-size
@@ -45,7 +45,7 @@ public actor SecureEnclaveSecureArea: SecureArea {
             dicts.append([kSecValueData as String: key.dataRepresentation])
             res.append(CoseKey(crv: .P256, x963Representation: key.publicKey.x963Representation))
         }
-        let kbi = KeyBatchInfo(secureAreaName: Self.name, crv: .P256, usedCounts: Array(repeating: 0, count: batchSize), credentialPolicy: keyOptions?.credentialPolicy ?? .rotateUse)
+        let kbi = KeyBatchInfo(secureAreaName: Self.name, crv: .P256, usedCounts: Array(repeating: 0, count: batchSize), credentialPolicy: credentialOptions.credentialPolicy)
         try await storage.writeKeyInfo(id: id, dict: [kSecValueData as String: kbi.toData() ?? Data(), kSecAttrDescription as String: Self.defaultEcCurve.jwkName.data(using: .utf8)!])
         try await storage.writeKeyDataBatch(id: id, startIndex: 0, dicts: dicts, keyOptions: keyOptions)
         return res

--- a/Sources/MdocSecurity18013/SecureAreaImplementations/SoftwareSecureArea.swift
+++ b/Sources/MdocSecurity18013/SecureAreaImplementations/SoftwareSecureArea.swift
@@ -35,7 +35,7 @@ public actor SoftwareSecureArea: SecureArea {
     nonisolated public static func create(storage: any MdocDataModel18013.SecureKeyStorage) -> SoftwareSecureArea {
         SoftwareSecureArea(storage: storage)
     }
-    
+
     public func createKeyMaterial(ecCurve: CoseEcCurve) throws -> (x963Priv: Data, x963Pub: Data) {
         switch ecCurve {
         case .P256: let key = P256.Signing.PrivateKey(compactRepresentable: false); return (key.x963Representation, key.publicKey.x963Representation)
@@ -44,10 +44,10 @@ public actor SoftwareSecureArea: SecureArea {
         default: throw SecureAreaError("Unsupported curve \(ecCurve)")
         }
     }
-    
-    public func createKeyBatch(id: String, keyOptions: KeyOptions?) async throws -> [CoseKey] {
+
+    public func createKeyBatch(id: String, credentialOptions: CredentialOptions, keyOptions: KeyOptions?) async throws -> [CoseKey] {
         let ecCurve = keyOptions?.curve ?? .P256
-        let batchSize = keyOptions?.batchSize ?? 1
+        let batchSize = credentialOptions.batchSize
         var res: [CoseKey] = []; res.reserveCapacity(batchSize)
         var dicts = [[String: Data]](); dicts.reserveCapacity(batchSize)
         for _ in 0..<batchSize {
@@ -55,12 +55,12 @@ public actor SoftwareSecureArea: SecureArea {
             dicts.append([kSecValueData as String: x963Priv])
             res.append(CoseKey(crv: ecCurve, x963Representation: x963Pub))
         }
-        let kbi = KeyBatchInfo(secureAreaName: Self.name, crv: ecCurve, usedCounts: Array(repeating: 0, count: batchSize), credentialPolicy: keyOptions?.credentialPolicy ?? .rotateUse)
+        let kbi = KeyBatchInfo(secureAreaName: Self.name, crv: ecCurve, usedCounts: Array(repeating: 0, count: batchSize), credentialPolicy: credentialOptions.credentialPolicy)
         try await storage.writeKeyInfo(id: id, dict: [kSecValueData as String: kbi.toData() ?? Data(), kSecAttrDescription as String: ecCurve.jwkName.data(using: .utf8)!])
         try await storage.writeKeyDataBatch(id: id, startIndex: 0, dicts: dicts, keyOptions: keyOptions)
         return res
     }
-    
+
     /// delete key
     public func deleteKeyBatch(id: String, startIndex: Int, batchSize: Int) async throws {
         try await storage.deleteKeyBatch(id: id, startIndex: startIndex, batchSize: batchSize)

--- a/Tests/MdocSecurity18013Tests/InMemoryP256SecureArea.swift
+++ b/Tests/MdocSecurity18013Tests/InMemoryP256SecureArea.swift
@@ -41,7 +41,7 @@ public actor InMemoryP256SecureArea: SecureArea {
         return CoseKey(crv: .P256, x963Representation: key.publicKey.x963Representation)
     }
 
-    public func createKeyBatch(id: String, keyOptions: KeyOptions?) async throws -> [CoseKey] {
+    public func createKeyBatch(id: String, credentialOptions: CredentialOptions, keyOptions: KeyOptions?) async throws -> [CoseKey] {
         let res = try await createKey(id: id, index: 0, keyOptions: keyOptions)
         return [res]
     }


### PR DESCRIPTION
Refactor the `createKeyBatch` method signatures to include `credentialOptions`, enhancing flexibility in key batch creation. Update the dependency to the latest version for improved functionality.