### PR TITLE
Downgrade swift-tools-version for compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Downgrade the Swift tools version from 6.2 to 6.0 to ensure compatibility with older environments.