### PR TITLE
Update eudi-lib-ios-iso18013-data-model to version 0.11.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "7f5ead2dc26415ecc91f2eef4071fee8a0ccc41ff1531238d5e4c11c693e27e5",
+  "originHash" : "aee7b3dfe2856e059dee5a6d7094805392b0c8e9f00cadf81e21741c0e95e318",
   "pins" : [
     {
       "identity" : "eudi-lib-ios-iso18013-data-model",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "a90e22376b1b81d33a9e09c7e46dab7cab1d9348",
-        "version" : "0.11.1"
+        "revision" : "e489425f82effbac1f4c260bfa1c05ba64fd8f62",
+        "version" : "0.11.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         // .package(path: "../eudi-lib-ios-iso18013-data-model"),
-        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git", exact: "0.11.1"),
+        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git", exact: "0.11.2"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
         .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMajor(from: "1.0.0")),
     ],


### PR DESCRIPTION
Update the dependency for eudi-lib-ios-iso18013-data-model to the latest version, ensuring compatibility and access to new features.