### PR TITLE
fix: persist generated SecKey entries as ThisDeviceOnly

### DIFF
--- a/Sources/MdocSecurity18013/SecureAreaImplementations/SecKeyExtensions.swift
+++ b/Sources/MdocSecurity18013/SecureAreaImplementations/SecKeyExtensions.swift
@@ -114,7 +114,11 @@ extension SecKey {
         var attributes: [String: Any] = [kSecAttrKeyType as String: type.secAttrKeyTypeValue, kSecAttrKeyClass as String: kSecAttrKeyClassPrivate, kSecAttrKeySizeInBits as String: NSNumber(integerLiteral: bits)]
         if let keyId {
             let tag = keyId.data(using: .utf8)!
-            attributes[kSecPrivateKeyAttrs as String] = [kSecAttrIsPermanent as String: true, kSecAttrApplicationTag as String: tag]
+            attributes[kSecPrivateKeyAttrs as String] = [
+                kSecAttrIsPermanent as String: true,
+                kSecAttrApplicationTag as String: tag,
+                kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            ]
         }
         var error: Unmanaged<CFError>?
         guard let key = SecKeyCreateRandomKey(attributes as CFDictionary, &error) else { throw error!.takeRetainedValue() as Error }


### PR DESCRIPTION
## Summary
Store generated `SecKey` keychain entries with device-bound accessibility so the persisted keys are not migrated via backups.

## Motivation
This aligns secure key persistence with the expected device-bound behavior for sensitive key material.

## Testing
Manual verification in an app integration using encrypted iTunes backup inspection:
- before the change, the relevant persisted key entries were present in the backup
- after the change, those entries were no longer present
