### PR TITLE
Refactor CRL handling, enforce validation, and improve security measures

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 EU Digital Identity Wallet
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 (1) google/identity-credential (available at https://github.com/google/identity-credential)
-Certain file packages were originally created under the Apache License, Version 2.0.  These files have been copied into this project and modified.  All modifications are Copyright 2023 European Commission, and are licensed under the Apache License, Version 2.0.
+Certain file packages were originally created under the Apache License, Version 2.0.  These files have been copied into this project and modified.  All modifications are Copyright 2026 European Commission, and are licensed under the Apache License, Version 2.0.
 
 Original License:
                                  Apache License

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "95b62044b46c3cd9b0c8929e224648f316fc176483bf175afe49be13c76a6102",
+  "originHash" : "0a1823d10faaeebf675a3013e4eb7b0dc81f9775197748eed7fad924b81d5689",
   "pins" : [
     {
       "identity" : "eudi-lib-ios-iso18013-data-model",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "7252e2070e608d693909ab0e9a873db7f801e61f",
-        "version" : "0.13.0"
+        "revision" : "87b0059b1da7b6c195fe78875637f7130cb4ac54",
+        "version" : "0.14.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         // .package(path: "../eudi-lib-ios-iso18013-data-model"),
-        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git", exact: "0.13.0"),
+        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git", exact: "0.14.0"),
         .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMajor(from: "1.0.0")),
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The released software is a initial development release version:
 
 ### License details
 
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/Extensions.swift
+++ b/Sources/MdocSecurity18013/Extensions.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/Extensions.swift
+++ b/Sources/MdocSecurity18013/Extensions.swift
@@ -34,8 +34,8 @@ extension UInt32 {
     return Data(bytes: &int, count: MemoryLayout<UInt32>.size)
   }
 	
-	/// Little endian encoding of bytes
-  public var byteArrayLittleEndian: [UInt8] {
+	/// Big endian encoding of bytes
+  public var byteArrayBigEndian: [UInt8] {
     return [
       UInt8((self & 0xFF000000) >> 24),
       UInt8((self & 0x00FF0000) >> 16),

--- a/Sources/MdocSecurity18013/IssuerAuthentication/DigestCalculations.swift
+++ b/Sources/MdocSecurity18013/IssuerAuthentication/DigestCalculations.swift
@@ -1,7 +1,7 @@
 /// Utility functions that can be used for issuer authentication
 
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/IssuerAuthentication/MsoValidation.swift
+++ b/Sources/MdocSecurity18013/IssuerAuthentication/MsoValidation.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/IssuerAuthentication/MsoValidation.swift
+++ b/Sources/MdocSecurity18013/IssuerAuthentication/MsoValidation.swift
@@ -20,15 +20,23 @@ import MdocDataModel18013
 import SwiftCBOR
 import X509
 
+public struct MsoValidationOptions: Sendable {
+    public let rejectIfValidUntilExceedsCertificateValidity: Bool
+
+    public init(rejectIfValidUntilExceedsCertificateValidity: Bool = false) {
+        self.rejectIfValidUntilExceedsCertificateValidity = rejectIfValidUntilExceedsCertificateValidity
+    }
+}
+
 extension IssuerSigned {
-    public func validate(docType: String) throws(MsoValidationError) {
+    public func validate(docType: String, options: MsoValidationOptions = .init()) throws(MsoValidationError) {
         // Perform validation logic here
         let msoValidationRules: [(MobileSecurityObject) -> [MsoValidationError]?] =
             [
                 { if $0.docType == docType { nil } else { [.docTypeNotMatches($0.docType)] } },
                 { if DigestAlgorithmKind(rawValue: $0.digestAlgorithm) != nil { nil } else { [.unsupportedDigestAlgorithm($0.digestAlgorithm)] } },
                 { validateDigestValues(mso: $0) },
-                { validateValidityInfo(mso: $0) },
+                { validateValidityInfo(mso: $0, options: options) },
                 { _ in validateMsoSignature() },
             ]
         let errors: [MsoValidationError] = msoValidationRules.compactMap { $0(issuerAuth.mso) }.flatMap { $0 }
@@ -54,13 +62,17 @@ extension IssuerSigned {
         return if errorList.isEmpty {nil } else { errorList }
     }
 
-    func validateValidityInfo(mso: MobileSecurityObject) -> [MsoValidationError]? {
+    func validateValidityInfo(mso: MobileSecurityObject, options: MsoValidationOptions = .init()) -> [MsoValidationError]? {
         guard !issuerAuth.x5chain.isEmpty, let dsCert = try? X509.Certificate(derEncoded: issuerAuth.x5chain[0]) else { return [.signatureVerificationFailed("No issuer certificates provided in x5chain")] }
         guard let sd = mso.validityInfo.signed.convertToLocalDate(), let vf = mso.validityInfo.validFrom.convertToLocalDate(), let vu = mso.validityInfo.validUntil.convertToLocalDate() else { return [.validityInfo("MSO validity contains invalid strings")]}
         var errorList: [MsoValidationError] = []
         if !(sd >= dsCert.notValidBefore && sd <= dsCert.notValidAfter) { errorList.append(.validityInfo("The 'signed' date is not within the validity period of the certificate in the MSO: \(sd.formatted()) (\(dsCert.notValidBefore.formatted()) - \(dsCert.notValidAfter.formatted()))")) }
-		if !(vf <= .now && vf <= vu) { errorList.append(.validityInfo("Current timestamp is not equal or later than the ‘validFrom’ element: \(vf.formatted())")) }
+		if !(vf <= .now) { errorList.append(.validityInfo("Current timestamp is not equal or later than the ‘validFrom’ element: \(vf.formatted())")) }
+		if !(vf < vu) { errorList.append(.validityInfo("The ‘validFrom’ element must be strictly earlier than the ‘validUntil’ element: \(vf.formatted()) >= \(vu.formatted())")) }
 		if !(vu >= .now) { errorList.append(.validityInfo("Current timestamp is not less than the ‘validUntil’ element: \(vu.formatted())")) }
+        if options.rejectIfValidUntilExceedsCertificateValidity && vu > dsCert.notValidAfter {
+            errorList.append(.validityInfo("The ‘validUntil’ element exceeds certificate validity: \(vu.formatted()) > \(dsCert.notValidAfter.formatted())"))
+        }
         return errorList.isEmpty ? nil : errorList
     }
 

--- a/Sources/MdocSecurity18013/IssuerAuthentication/MsoValidation.swift
+++ b/Sources/MdocSecurity18013/IssuerAuthentication/MsoValidation.swift
@@ -67,9 +67,9 @@ extension IssuerSigned {
         guard let sd = mso.validityInfo.signed.convertToLocalDate(), let vf = mso.validityInfo.validFrom.convertToLocalDate(), let vu = mso.validityInfo.validUntil.convertToLocalDate() else { return [.validityInfo("MSO validity contains invalid strings")]}
         var errorList: [MsoValidationError] = []
         if !(sd >= dsCert.notValidBefore && sd <= dsCert.notValidAfter) { errorList.append(.validityInfo("The 'signed' date is not within the validity period of the certificate in the MSO: \(sd.formatted()) (\(dsCert.notValidBefore.formatted()) - \(dsCert.notValidAfter.formatted()))")) }
-		if !(vf <= .now) { errorList.append(.validityInfo("Current timestamp is not equal or later than the ‘validFrom’ element: \(vf.formatted())")) }
+		if !(vf <= .now.addingTimeInterval(60)) { errorList.append(.validityInfo("Current timestamp is not equal or later than the ‘validFrom’ element: \(vf.formatted())")) }
 		if !(vf < vu) { errorList.append(.validityInfo("The ‘validFrom’ element must be strictly earlier than the ‘validUntil’ element: \(vf.formatted()) >= \(vu.formatted())")) }
-		if !(vu >= .now) { errorList.append(.validityInfo("Current timestamp is not less than the ‘validUntil’ element: \(vu.formatted())")) }
+        if !(vu.addingTimeInterval(60) >= .now) { errorList.append(.validityInfo("Current timestamp is not less than the ‘validUntil’ element: \(vu.formatted())")) }
         if options.rejectIfValidUntilExceedsCertificateValidity && vu > dsCert.notValidAfter {
             errorList.append(.validityInfo("The ‘validUntil’ element exceeds certificate validity: \(vu.formatted()) > \(dsCert.notValidAfter.formatted())"))
         }

--- a/Sources/MdocSecurity18013/IssuerAuthentication/MsoValidationError.swift
+++ b/Sources/MdocSecurity18013/IssuerAuthentication/MsoValidationError.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/MdocAuthentication/CoseMAC.swift
+++ b/Sources/MdocSecurity18013/MdocAuthentication/CoseMAC.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/MdocAuthentication/CoseSignature.swift
+++ b/Sources/MdocSecurity18013/MdocAuthentication/CoseSignature.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/MdocAuthentication/DeviceAuthentication.swift
+++ b/Sources/MdocSecurity18013/MdocAuthentication/DeviceAuthentication.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/MdocAuthentication/DeviceAuthentication.swift
+++ b/Sources/MdocSecurity18013/MdocAuthentication/DeviceAuthentication.swift
@@ -23,7 +23,7 @@ import MdocDataModel18013
 /// This structure is not transfered, only computed
 /// The mDL calculates this ephemeral MAC by performing KDF(ECDH(mDL private key, reader ephemeral public key)) and the mDL reader calculates this ephemeral MAC by performing KDF(ECDH(mDL public key, reader ephemeral private key)).
   public struct DeviceAuthentication: Sendable {
-    let sessionTranscript: CBOREncodable & Sendable
+    let sessionTranscript: SessionTranscript
     let docType: String
     let deviceNameSpacesRawData: [UInt8]
   }

--- a/Sources/MdocSecurity18013/MdocAuthentication/MdocAuthentication.swift
+++ b/Sources/MdocSecurity18013/MdocAuthentication/MdocAuthentication.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/MdocAuthentication/MdocAuthentication.swift
+++ b/Sources/MdocSecurity18013/MdocAuthentication/MdocAuthentication.swift
@@ -29,12 +29,11 @@ import SwiftCBOR
 /// let mdocAuth = MdocAuthentication(transcript: sessionEncr.transcript, authKeys: authKeys)
 /// ```
 public struct MdocAuthentication: Sendable {
-    // The session transcript object, can be a `SessionTranscript` or any other object that conforms to`CBOREncodable`
-    let sessionTranscript: CBOREncodable & Sendable
+    let sessionTranscript: SessionTranscript
     let authKeys: CoseKeyExchange
     var sessionTranscriptBytes: [UInt8] { sessionTranscript.toCBOR(options: CBOROptions()).taggedEncoded.encode(options: CBOROptions()) }
 
-	public init(sessionTranscript: CBOREncodable & Sendable, authKeys: CoseKeyExchange) {
+	public init(sessionTranscript: SessionTranscript, authKeys: CoseKeyExchange) {
 		self.sessionTranscript = sessionTranscript
 		self.authKeys = authKeys
 	}

--- a/Sources/MdocSecurity18013/MdocReaderAuthentication/MdocReaderAuthentication.swift
+++ b/Sources/MdocSecurity18013/MdocReaderAuthentication/MdocReaderAuthentication.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/MdocReaderAuthentication/MdocReaderAuthentication.swift
+++ b/Sources/MdocSecurity18013/MdocReaderAuthentication/MdocReaderAuthentication.swift
@@ -34,7 +34,7 @@ public struct MdocReaderAuthentication: Sendable {
 	///   - readerAuthCertificate: The reader auth certificate decoded from above reader-auth structure. Contains the mdoc reader public key
 	///   - itemsRequestRawData: Reader's item request raw data
 	/// - Returns: (True if verification of reader auth has valid signature, reason for certificate validation failure)
-	public func validateReaderAuth(readerAuthCBOR: CBOR, readerAuthX5c: [Data], itemsRequestRawData: [UInt8], rootIaca: [x5chain]? = nil) throws -> (Bool, String?) {
+	public func validateReaderAuth(readerAuthCBOR: CBOR, readerAuthX5c: [Data], itemsRequestRawData: [UInt8], rootIaca: [x5chain]) throws -> (Bool, String?) {
 		let ra = ReaderAuthentication(sessionTranscript: transcript, itemsRequestRawData: itemsRequestRawData)
 		let contentBytes = ra.toCBOR(options: CBOROptions()).taggedEncoded.encode(options: CBOROptions())
 		let secCerts = readerAuthX5c.compactMap { SecCertificateCreateWithData(nil, $0 as CFData) }
@@ -43,7 +43,7 @@ public struct MdocReaderAuthentication: Sendable {
 		guard let publicKeyx963 = SecurityHelpers.getPublicKeyx963(ref: secCerts.first!) else { return (false, "Public key not found in certificate") }
 		let b1 = try readerAuth.validateDetachedCoseSign1(payloadData: Data(contentBytes), publicKey_x963: publicKeyx963)
 		guard b1 else { return (false, "Reader auth signature validation failed") }
-		let b2 = SecurityHelpers.isMdocX5cValid(secCerts: secCerts, usage: .mdocReaderAuth, rootIaca: rootIaca ?? [])
+		let b2 = SecurityHelpers.isMdocX5cValid(secCerts: secCerts, usage: .mdocReaderAuth, rootIaca: rootIaca)
 		if !b2.isValid { logger.warning(Logger.Message(unicodeScalarLiteral: b2.validationMessages.joined(separator: "\n"))) }
 		return (b1 && b2.isValid, b2.validationMessages.joined(separator: "\n"))
 	}

--- a/Sources/MdocSecurity18013/MdocReaderAuthentication/ReaderAuthentication.swift
+++ b/Sources/MdocSecurity18013/MdocReaderAuthentication/ReaderAuthentication.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/MdocSecurity18013.swift
+++ b/Sources/MdocSecurity18013/MdocSecurity18013.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/SecureAreaImplementations/SecKeyExtensions.swift
+++ b/Sources/MdocSecurity18013/SecureAreaImplementations/SecKeyExtensions.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/SecureAreaImplementations/SecureEnclaveSecureArea.swift
+++ b/Sources/MdocSecurity18013/SecureAreaImplementations/SecureEnclaveSecureArea.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/SecureAreaImplementations/SecureEnclaveSecureArea.swift
+++ b/Sources/MdocSecurity18013/SecureAreaImplementations/SecureEnclaveSecureArea.swift
@@ -46,7 +46,8 @@ public actor SecureEnclaveSecureArea: SecureArea {
             res.append(CoseKey(crv: .P256, x963Representation: key.publicKey.x963Representation))
         }
         let kbi = KeyBatchInfo(secureAreaName: Self.name, crv: .P256, usedCounts: Array(repeating: 0, count: batchSize), credentialPolicy: credentialOptions.credentialPolicy)
-        try await storage.writeKeyInfo(id: id, dict: [kSecValueData as String: kbi.toData() ?? Data(), kSecAttrDescription as String: Self.defaultEcCurve.jwkName.data(using: .utf8)!])
+        guard let kbiData = kbi.toData() else { throw SecureAreaError("Failed to encode KeyBatchInfo") }
+        try await storage.writeKeyInfo(id: id, dict: [kSecValueData as String: kbiData, kSecAttrDescription as String: Self.defaultEcCurve.jwkName.data(using: .utf8)!])
         try await storage.writeKeyDataBatch(id: id, startIndex: 0, dicts: dicts, keyOptions: keyOptions)
         return res
     }

--- a/Sources/MdocSecurity18013/SecureAreaImplementations/SoftwareSecureArea.swift
+++ b/Sources/MdocSecurity18013/SecureAreaImplementations/SoftwareSecureArea.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2023 European Commission
+ Copyright (c) 2026 European Commission
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/SecureAreaImplementations/SoftwareSecureArea.swift
+++ b/Sources/MdocSecurity18013/SecureAreaImplementations/SoftwareSecureArea.swift
@@ -133,13 +133,6 @@ public actor SoftwareSecureArea: SecureArea {
         return sharedSecret
     }
 
-    func getInfoAndCurve(id: String) async throws -> ([String:Data], CoseEcCurve) {
-        let keyInfoDict = try await storage.readKeyInfo(id: id)
-        guard let jwkNameData = keyInfoDict[kSecAttrDescription as String], let jwkName = String(data: jwkNameData, encoding: .utf8) else { throw SecureAreaError("Key info description not found") }
-        let curve = try CoseEcCurve.fromJwkName(jwkName)
-        return (keyInfoDict, curve)
-    }
-
     func getKeyData(id: String, index: Int) async throws -> Data {
         let keyDataDict = try await storage.readKeyData(id: id, index: index)
         guard let x963Representation = keyDataDict[kSecValueData as String] else { throw SecureAreaError("Key data not found") }

--- a/Sources/MdocSecurity18013/SecureAreaImplementations/SoftwareSecureArea.swift
+++ b/Sources/MdocSecurity18013/SecureAreaImplementations/SoftwareSecureArea.swift
@@ -56,7 +56,8 @@ public actor SoftwareSecureArea: SecureArea {
             res.append(CoseKey(crv: ecCurve, x963Representation: x963Pub))
         }
         let kbi = KeyBatchInfo(secureAreaName: Self.name, crv: ecCurve, usedCounts: Array(repeating: 0, count: batchSize), credentialPolicy: credentialOptions.credentialPolicy)
-        try await storage.writeKeyInfo(id: id, dict: [kSecValueData as String: kbi.toData() ?? Data(), kSecAttrDescription as String: ecCurve.jwkName.data(using: .utf8)!])
+        guard let kbiData = kbi.toData() else { throw SecureAreaError("Failed to encode KeyBatchInfo") }
+        try await storage.writeKeyInfo(id: id, dict: [kSecValueData as String: kbiData, kSecAttrDescription as String: ecCurve.jwkName.data(using: .utf8)!])
         try await storage.writeKeyDataBatch(id: id, startIndex: 0, dicts: dicts, keyOptions: keyOptions)
         return res
     }

--- a/Sources/MdocSecurity18013/SessionEncryption/EckaDHAgreement.swift
+++ b/Sources/MdocSecurity18013/SessionEncryption/EckaDHAgreement.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/SessionEncryption/SessionData.swift
+++ b/Sources/MdocSecurity18013/SessionEncryption/SessionData.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/SessionEncryption/SessionEncryption.swift
+++ b/Sources/MdocSecurity18013/SessionEncryption/SessionEncryption.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/SessionEncryption/SessionEncryption.swift
+++ b/Sources/MdocSecurity18013/SessionEncryption/SessionEncryption.swift
@@ -65,7 +65,7 @@ public struct SessionEncryption: Sendable {
 		var dataNonce = Data()
 		let identifier = isEncrypt ? encryptionIdentifier : decryptionIdentifier
 		dataNonce.append(Data(identifier))
-		dataNonce.append(Data(counter.byteArrayLittleEndian))
+		dataNonce.append(Data(counter.byteArrayBigEndian))
 		let nonce = try AES.GCM.Nonce(data: dataNonce)
 		return nonce
 	}

--- a/Sources/MdocSecurity18013/SessionEncryption/SessionEstablishment.swift
+++ b/Sources/MdocSecurity18013/SessionEncryption/SessionEstablishment.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/SessionEncryption/SessionRole.swift
+++ b/Sources/MdocSecurity18013/SessionEncryption/SessionRole.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/SessionEncryption/SessionTranscript.swift
+++ b/Sources/MdocSecurity18013/SessionEncryption/SessionTranscript.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/x509certificates/CRL.swift
+++ b/Sources/MdocSecurity18013/x509certificates/CRL.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/x509certificates/CRL.swift
+++ b/Sources/MdocSecurity18013/x509certificates/CRL.swift
@@ -19,10 +19,10 @@ import SwiftASN1
 import X509
 
 struct CRL: PEMParseable, DERParseable {
-	var serialNumber: Int64
+	var version: Int64
 	var issuer: DistinguishedName
-	var validity: UTCTime
-	var subject: UTCTime
+	var thisUpdate: UTCTime
+	var nextUpdate: UTCTime
 	var revokedSerials: [CRLSerialInfo] = []
 	static let defaultPEMDiscriminator: String = "X509 CRL"
 
@@ -48,15 +48,22 @@ struct CRL: PEMParseable, DERParseable {
 		guard let n1 = nodesIter.next() else { throw Self.toError(node: node) } // tbsCertificate
 		guard case .constructed(let nodes1) = n1.content else { throw Self.toError(node: n1) }
 		var nodes1Iter = nodes1.makeIterator()
-		serialNumber = try Int64(derEncoded: &nodes1Iter)
+		version = try Int64(derEncoded: &nodes1Iter)
 		_ = nodes1Iter.next() // skip signature
 		guard let issuerNode = nodes1Iter.next() else { throw Self.toError(node: n1) }
 		issuer = try DistinguishedName(derEncoded: issuerNode)
-		validity = try SwiftASN1.UTCTime(derEncoded: &nodes1Iter)
-		subject = try SwiftASN1.UTCTime(derEncoded: &nodes1Iter)
+		thisUpdate = try SwiftASN1.UTCTime(derEncoded: &nodes1Iter)
+		nextUpdate = try SwiftASN1.UTCTime(derEncoded: &nodes1Iter)
 		guard let n2 = nodes1Iter.next() else { throw Self.toError(node: n1) } // subject public key info
 		guard case .constructed(let nodes3) = n2.content else { throw Self.toError(node: n2) }
 		revokedSerials = nodes3.compactMap { try? CRLSerialInfo(derEncoded: $0) }
+	}
+
+	var isValid: Bool {
+		let c = Calendar.current
+		let dc = c.dateComponents(in: TimeZone(identifier: "UTC")!, from: Date())
+		guard let now = try? UTCTime(year: dc.year!, month: dc.month!, day: dc.day!, hours: dc.hour!, minutes: dc.minute!, seconds: dc.second!) else { return false }
+		return thisUpdate <= now && now <= nextUpdate
 	}
 
 	static func toError(node: SwiftASN1.ASN1Node) -> NSError {

--- a/Sources/MdocSecurity18013/x509certificates/CRL.swift
+++ b/Sources/MdocSecurity18013/x509certificates/CRL.swift
@@ -24,6 +24,9 @@ struct CRL: PEMParseable, DERParseable {
 	var thisUpdate: UTCTime
 	var nextUpdate: UTCTime
 	var revokedSerials: [CRLSerialInfo] = []
+	var tbsBytes: ArraySlice<UInt8>
+	var signatureAlgorithmOID: ASN1ObjectIdentifier
+	var signatureBitBytes: ArraySlice<UInt8>
 	static let defaultPEMDiscriminator: String = "X509 CRL"
 
 	struct CRLSerialInfo: DERImplicitlyTaggable, CustomStringConvertible {
@@ -45,18 +48,56 @@ struct CRL: PEMParseable, DERParseable {
 	init(derEncoded node: SwiftASN1.ASN1Node) throws {
 		guard case .constructed(let nodes) = node.content else { throw Self.toError(node: node) }
 		var nodesIter = nodes.makeIterator()
-		guard let n1 = nodesIter.next() else { throw Self.toError(node: node) } // tbsCertificate
-		guard case .constructed(let nodes1) = n1.content else { throw Self.toError(node: n1) }
+		guard let tbsCertListNode = nodesIter.next() else { throw Self.toError(node: node) } // tbsCertList
+		tbsBytes = tbsCertListNode.encodedBytes
+		// Parse signatureAlgorithm (SEQUENCE { OID, optional params })
+		guard let sigAlgNode = nodesIter.next() else { throw Self.toError(node: node) }
+		guard case .constructed(let sigAlgNodes) = sigAlgNode.content else { throw Self.toError(node: sigAlgNode) }
+		var sigAlgIter = sigAlgNodes.makeIterator()
+		signatureAlgorithmOID = try ASN1ObjectIdentifier(derEncoded: &sigAlgIter)
+		// Parse signatureValue (BIT STRING)
+		let sigBitString = try ASN1BitString(derEncoded: &nodesIter)
+		signatureBitBytes = sigBitString.bytes[...]
+		// Parse tbsCertList fields
+		guard case .constructed(let nodes1) = tbsCertListNode.content else { throw Self.toError(node: tbsCertListNode) }
 		var nodes1Iter = nodes1.makeIterator()
 		version = try Int64(derEncoded: &nodes1Iter)
-		_ = nodes1Iter.next() // skip signature
-		guard let issuerNode = nodes1Iter.next() else { throw Self.toError(node: n1) }
+		_ = nodes1Iter.next() // skip signature algorithm (repeated in tbsCertList)
+		guard let issuerNode = nodes1Iter.next() else { throw Self.toError(node: tbsCertListNode) }
 		issuer = try DistinguishedName(derEncoded: issuerNode)
 		thisUpdate = try SwiftASN1.UTCTime(derEncoded: &nodes1Iter)
 		nextUpdate = try SwiftASN1.UTCTime(derEncoded: &nodes1Iter)
-		guard let n2 = nodes1Iter.next() else { throw Self.toError(node: n1) } // subject public key info
+		guard let n2 = nodes1Iter.next() else { throw Self.toError(node: tbsCertListNode) } // revokedCertificates
 		guard case .constructed(let nodes3) = n2.content else { throw Self.toError(node: n2) }
 		revokedSerials = nodes3.compactMap { try? CRLSerialInfo(derEncoded: $0) }
+	}
+
+	// OID constants for signature algorithms not publicly exposed by swift-asn1
+	private static let oidEcdsaWithSHA256: ASN1ObjectIdentifier = [1, 2, 840, 10045, 4, 3, 2]
+	private static let oidEcdsaWithSHA384: ASN1ObjectIdentifier = [1, 2, 840, 10045, 4, 3, 3]
+	private static let oidEcdsaWithSHA512: ASN1ObjectIdentifier = [1, 2, 840, 10045, 4, 3, 4]
+	private static let oidSha1WithRSAEncryption: ASN1ObjectIdentifier = [1, 2, 840, 113549, 1, 1, 5]
+	private static let oidEd25519: ASN1ObjectIdentifier = [1, 3, 101, 112]
+
+	/// Map the CRL's signature algorithm OID to the corresponding `Certificate.SignatureAlgorithm`.
+	var signatureAlgorithm: Certificate.SignatureAlgorithm? {
+		switch signatureAlgorithmOID {
+		case Self.oidEcdsaWithSHA256: return .ecdsaWithSHA256
+		case Self.oidEcdsaWithSHA384: return .ecdsaWithSHA384
+		case Self.oidEcdsaWithSHA512: return .ecdsaWithSHA512
+		case .AlgorithmIdentifier.sha256WithRSAEncryption: return .sha256WithRSAEncryption
+		case .AlgorithmIdentifier.sha384WithRSAEncryption: return .sha384WithRSAEncryption
+		case .AlgorithmIdentifier.sha512WithRSAEncryption: return .sha512WithRSAEncryption
+		case Self.oidSha1WithRSAEncryption: return .sha1WithRSAEncryption
+		case Self.oidEd25519: return .ed25519
+		default: return nil
+		}
+	}
+
+	/// Verify the CRL signature against the issuing certificate's public key.
+	func verifySignature(issuer: X509.Certificate) -> Bool {
+		guard let sigAlg = signatureAlgorithm else { return false }
+		return issuer.publicKey.isValidSignature(signatureBitBytes, for: tbsBytes, signatureAlgorithm: sigAlg)
 	}
 
 	var isValid: Bool {

--- a/Sources/MdocSecurity18013/x509certificates/CRL.swift
+++ b/Sources/MdocSecurity18013/x509certificates/CRL.swift
@@ -67,9 +67,10 @@ struct CRL: PEMParseable, DERParseable {
 		issuer = try DistinguishedName(derEncoded: issuerNode)
 		thisUpdate = try SwiftASN1.UTCTime(derEncoded: &nodes1Iter)
 		nextUpdate = try SwiftASN1.UTCTime(derEncoded: &nodes1Iter)
-		guard let n2 = nodes1Iter.next() else { throw Self.toError(node: tbsCertListNode) } // revokedCertificates
-		guard case .constructed(let nodes3) = n2.content else { throw Self.toError(node: n2) }
-		revokedSerials = nodes3.compactMap { try? CRLSerialInfo(derEncoded: $0) }
+		// revokedCertificates is OPTIONAL; the next node may be extensions ([0] EXPLICIT) or absent
+		if let n2 = nodes1Iter.next(), n2.identifier == .sequence, case .constructed(let nodes3) = n2.content {
+			revokedSerials = try nodes3.map { try CRLSerialInfo(derEncoded: $0) }
+		}
 	}
 
 	// OID constants for signature algorithms not publicly exposed by swift-asn1

--- a/Sources/MdocSecurity18013/x509certificates/SecurityHelpers.swift
+++ b/Sources/MdocSecurity18013/x509certificates/SecurityHelpers.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Sources/MdocSecurity18013/x509certificates/SecurityHelpers.swift
+++ b/Sources/MdocSecurity18013/x509certificates/SecurityHelpers.swift
@@ -143,6 +143,10 @@ public class SecurityHelpers {
 				guard let crlUrl = URL(string: crl.distributionPoint) else { continue }
 				guard let pem = try? String(contentsOf: crlUrl) else { continue }
 				guard let crl = try? CRL(pemEncoded: pem) else { continue }
+				guard crl.isValid else {
+					logger.warning("CRL from \(crlUrl) is not within its validity period (thisUpdate: \(crl.thisUpdate), nextUpdate: \(crl.nextUpdate))")
+					continue
+				}
 				res.append(contentsOf: crl.revokedSerials.map(\.serial))
 			}
 		}

--- a/Sources/MdocSecurity18013/x509certificates/SecurityHelpers.swift
+++ b/Sources/MdocSecurity18013/x509certificates/SecurityHelpers.swift
@@ -141,11 +141,22 @@ public class SecurityHelpers {
 		if let ext = x509root.extensions[oid: .X509ExtensionID.cRLDistributionPoints], let crlDistr = try? CRLDistributions(derEncoded: ext.value) {
 			for crl in crlDistr.crls {
 				guard let crlUrl = URL(string: crl.distributionPoint) else { continue }
-				guard let pem = try? String(contentsOf: crlUrl) else { continue }
-				guard let crl = try? CRL(pemEncoded: pem) else { continue }
+				guard let crlData = try? Data(contentsOf: crlUrl) else { continue }
+				let crl: CRL
+				if let pemString = String(data: crlData, encoding: .utf8), pemString.contains("-----BEGIN") {
+					guard let pemCrl = try? CRL(pemEncoded: pemString) else { continue }
+					crl = pemCrl
+				} else {
+					guard let derCrl = try? CRL(derEncoded: Array(crlData)) else { continue }
+					crl = derCrl
+				}
 				guard crl.isValid else {
 					let errorMessage = "CRL from \(crlUrl) is not within its validity period (thisUpdate: \(crl.thisUpdate), nextUpdate: \(crl.nextUpdate))"
 					messages.append(errorMessage)
+					continue
+				}
+				guard crl.verifySignature(issuer: x509root) else {
+					messages.append("CRL from \(crlUrl) has an invalid signature")
 					continue
 				}
 				bs.append(contentsOf: crl.revokedSerials.map(\.serial))

--- a/Sources/MdocSecurity18013/x509certificates/SecurityHelpers.swift
+++ b/Sources/MdocSecurity18013/x509certificates/SecurityHelpers.swift
@@ -82,7 +82,7 @@ public class SecurityHelpers {
 				if usage == .mdocReaderAuth, let rootGns = x509root.getSubjectAlternativeNames(), let gns = x509cert.getSubjectAlternativeNames() {
 					guard gns.elementsEqual(rootGns) else { return (false, ["Issuer data rfc822Name or uniformResourceIdentifier do not match with root cert."], nil) }
 				}
-				let bs = fetchCRLSerialNumbers(x509root)
+				let bs = fetchCRLSerialNumbers(x509root, messages: &messages)
 				if !bs.isEmpty {
 					if bs.contains(x509cert.serialNumber) { return (false, ["Revoked issued Certificate"], rootCert)}
 					if bs.contains(x509root.serialNumber) { return (false,["Revoked Root Certificate"], rootCert)}
@@ -100,7 +100,7 @@ public class SecurityHelpers {
 		//if let error { logger.error("Error evaluating trust: \(error)") }
         return (isValid, error?.localizedDescription, (error as? NSError)?.code)
 	}
-    
+
     public static func isChainFound(secCerts: x5chain, rootIaca: [x5chain]) async -> (isValid: Bool, validationMessages: [String], rootCert: SecCertificate?) {
         var validationMessages: [String] = []
         guard let leafSecCert = secCerts.first, let leafCert = try? leafSecCert.certificate() else {
@@ -136,21 +136,22 @@ public class SecurityHelpers {
     }
   }
 
- public static func fetchCRLSerialNumbers(_ x509root: X509.Certificate) -> [Certificate.SerialNumber] {
-		var res = [Certificate.SerialNumber]()
+ public static func fetchCRLSerialNumbers(_ x509root: X509.Certificate, messages: inout [String]) -> [Certificate.SerialNumber] {
+		var bs = [Certificate.SerialNumber]()
 		if let ext = x509root.extensions[oid: .X509ExtensionID.cRLDistributionPoints], let crlDistr = try? CRLDistributions(derEncoded: ext.value) {
 			for crl in crlDistr.crls {
 				guard let crlUrl = URL(string: crl.distributionPoint) else { continue }
 				guard let pem = try? String(contentsOf: crlUrl) else { continue }
 				guard let crl = try? CRL(pemEncoded: pem) else { continue }
 				guard crl.isValid else {
-					logger.warning("CRL from \(crlUrl) is not within its validity period (thisUpdate: \(crl.thisUpdate), nextUpdate: \(crl.nextUpdate))")
+					let errorMessage = "CRL from \(crlUrl) is not within its validity period (thisUpdate: \(crl.thisUpdate), nextUpdate: \(crl.nextUpdate))"
+					messages.append(errorMessage)
 					continue
 				}
-				res.append(contentsOf: crl.revokedSerials.map(\.serial))
+				bs.append(contentsOf: crl.revokedSerials.map(\.serial))
 			}
 		}
-		return res
+		return bs
 	}
 
 	public static func verifyReaderAuthCert(_ x509: X509.Certificate, messages: inout [String]) {

--- a/Sources/MdocSecurity18013/x509certificates/SecurityHelpers.swift
+++ b/Sources/MdocSecurity18013/x509certificates/SecurityHelpers.swift
@@ -63,10 +63,10 @@ public class SecurityHelpers {
 		guard !x509cert.subject.isEmpty, let cn = getCommonName(ref: secCert), !cn.isEmpty else { return (false, ["Missing Common Name of Reader Certificate"], nil) }
 		guard !x509cert.signature.description.isEmpty else { return (false, ["Missing Signature data"], nil) }
 		if x509cert.serialNumber.description.isEmpty { messages.append("Missing Serial number") }
-		// not critical errors below
-		if x509cert.hasDuplicateExtensions() { messages.append("Duplicate extensions in Certificate") }
+		guard !x509cert.hasDuplicateExtensions() else { return (false, ["Duplicate extensions in Certificate"], nil) }
 		if usage == .mdocReaderAuth {
-			verifyReaderAuthCert(x509cert, messages: &messages)
+			let (isValidExt, extError) = verifyReaderAuthCert(x509cert, messages: &messages)
+			if !isValidExt { return (false, [extError ?? "Certificate extension validation failed"], nil) }
 			if let gns = x509cert.getSubjectAlternativeNames(), let gn = gns.first(where: { switch $0 { case .rfc822Name(_): true; case .uniformResourceIdentifier(_): true;  default: false } }) { logger.info("Alternative name \(gn.description)")}
 		}
 		SecTrustSetPolicies(trust, policy)
@@ -165,7 +165,10 @@ public class SecurityHelpers {
 		return bs
 	}
 
-	public static func verifyReaderAuthCert(_ x509: X509.Certificate, messages: inout [String]) {
+	/// Verify reader auth certificate extensions and properties.
+	/// - Returns: A tuple of (isValid, errorMessage). If isValid is false, validation must fail.
+	@discardableResult
+	public static func verifyReaderAuthCert(_ x509: X509.Certificate, messages: inout [String]) -> (Bool, String?) {
 		// check issuer
 		if !x509.issuer.isEmpty { logger.info("Issuer \(x509.issuer.description)")} else { messages.append("Missing Issuer") }
 		// check authority key identifier
@@ -185,12 +188,13 @@ public class SecurityHelpers {
 		// display extended OCSP extension
 		if let ext_ocsp = try? x509.extensions.authorityInformationAccess, let infoAccesses = ext_ocsp.infoAccesses, let infoAccess = infoAccesses.first, infoAccess.method == .ocspServer, !infoAccess.location.description.isEmpty { logger.info("OCSP server location: \(infoAccess.location.description)") }
 		if x509.signatureAlgorithm.isECDSA256or384or512 { logger.info("Signature algorithm is \(x509.signatureAlgorithm)")} else { messages.append("Signature algorithm must be ECDSA with SHA 256/384/512") }
-		// check for not allowed critical extensions
+		// check for not allowed critical extensions — must cause validation failure per RFC 5280 Section 4.2
 		let criticalExtensionOIDs: [String] = x509.extensions.filter(\.critical).map(\.oid).map(\.description)
 		let notAllowedCriticalExt = Set(criticalExtensionOIDs).intersection(Set(Self.nonAllowedExtensions))
-		if notAllowedCriticalExt.isEmpty { logger.info("Critical extensions correct") } else { messages.append("Not allowed critical extensions \(notAllowedCriticalExt)") }
+		if notAllowedCriticalExt.isEmpty { logger.info("Critical extensions correct") } else { return (false, "Not allowed critical extensions \(notAllowedCriticalExt)") }
 		// check crls existing
 		if let crlExt1 = x509.extensions[oid: .X509ExtensionID.cRLDistributionPoints], let crlExt2 = try? CRLDistributionPointsExtension(crlExt1), !crlExt2.crls.isEmpty, crlExt2.crls.allSatisfy(\.isNotEmpty) { logger.info("CRL Distribution extension found") } else { messages.append("Missing CRL Distribution extension") }
+		return (true, nil)
 	}
 
 	public static func getCommonName(ref: SecCertificate) -> String? {

--- a/Tests/MdocSecurity18013Tests/CRLTests.swift
+++ b/Tests/MdocSecurity18013Tests/CRLTests.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Tests/MdocSecurity18013Tests/CRLTests.swift
+++ b/Tests/MdocSecurity18013Tests/CRLTests.swift
@@ -15,10 +15,12 @@ limitations under the License.
 */
 import Foundation
 import Testing
+import Security
 import SwiftASN1
 import X509
 
 @testable import MdocSecurity18013
+@testable import MdocDataModel18013
 
 @Suite("CRL Tests")
 struct CRLTests {
@@ -54,6 +56,35 @@ struct CRLTests {
 	j0o=
 	-----END X509 CRL-----
 	"""
+
+    static let crlDistributionPointUrl = "https://preprod.pki.eudiw.dev/crl/pid_CA_UT_02.crl"
+
+	@Test("fetchCRLSerialNumbers validates CRL signature from distribution point")
+	func fetchCRLSerialNumbersFromDistributionPoint() throws {
+		let derData = try Data(contentsOf: Bundle.module.url(forResource: "pidissuerca02_ut", withExtension: "der")!)
+		let secCert = try #require(SecCertificateCreateWithData(nil, derData as CFData))
+		let x509root = try secCert.certificate()
+		// Verify the certificate has a CRL distribution point matching our URL
+		let ext = try #require(x509root.extensions[oid: .X509ExtensionID.cRLDistributionPoints])
+		let crlDistr = try CRLDistributions(derEncoded: ext.value)
+		#expect(crlDistr.crls.contains(where: { $0.distributionPoint == Self.crlDistributionPointUrl }))
+		// Fetch and parse the CRL (may be DER or PEM encoded), verifying its signature
+		let crlData = try Data(contentsOf: URL(string: Self.crlDistributionPointUrl)!)
+		let crl: CRL
+		if let pemString = String(data: crlData, encoding: .utf8), pemString.contains("-----BEGIN") {
+			crl = try CRL(pemEncoded: pemString)
+		} else {
+			crl = try CRL(derEncoded: Array(crlData))
+		}
+		#expect(crl.isValid)
+		#expect(crl.signatureAlgorithm != nil)
+		#expect(crl.verifySignature(issuer: x509root), "CRL signature must be valid against issuing CA")
+		// Also verify via fetchCRLSerialNumbers which integrates all checks
+		var messages = [String]()
+		let serials = SecurityHelpers.fetchCRLSerialNumbers(x509root, messages: &messages)
+		#expect(!messages.contains(where: { $0.contains("invalid signature") }), "fetchCRLSerialNumbers should not report signature errors: \(messages)")
+		print("Fetched \(serials.count) revoked serial(s), messages: \(messages)")
+	}
 
 	@Test("Parse valid CRL with no revoked certificates")
 	func parseEmptyCRL() throws {

--- a/Tests/MdocSecurity18013Tests/CRLTests.swift
+++ b/Tests/MdocSecurity18013Tests/CRLTests.swift
@@ -1,0 +1,117 @@
+/*
+Copyright (c) 2023 European Commission
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import Foundation
+import Testing
+import SwiftASN1
+import X509
+
+@testable import MdocSecurity18013
+
+@Suite("CRL Tests")
+struct CRLTests {
+
+	// Valid CRL with no revoked certificates (nextUpdate: 2036-03-31)
+	static let validEmptyCRLPEM = """
+	-----BEGIN X509 CRL-----
+	MIGpMFECAQEwCgYIKoZIzj0EAwIwEjEQMA4GA1UEAwwHVGVzdCBDQRcNMjYwNDAz
+	MTIxMjI5WhcNMzYwMzMxMTIxMjI5WqAOMAwwCgYDVR0UBAMCAQEwCgYIKoZIzj0E
+	AwIDSAAwRQIhALnLjSZVZeQ0GrnA9zZyPkQn4strgYXZCIhQmGxmyPNMAiBJDzHV
+	FLYTXJLcqvELdLUi++W5nDtJ3+MaSSRgnQPrZw==
+	-----END X509 CRL-----
+	"""
+
+	// Valid CRL with one revoked certificate (serial 02), nextUpdate: 2036-03-31
+	static let validRevokedCRLPEM = """
+	-----BEGIN X509 CRL-----
+	MIG/MGcCAQEwCgYIKoZIzj0EAwIwEjEQMA4GA1UEAwwHVGVzdCBDQRcNMjYwNDAz
+	MTIxMjM4WhcNMzYwMzMxMTIxMjM4WjAUMBICAQIXDTI2MDQwMzEyMTIzN1qgDjAM
+	MAoGA1UdFAQDAgECMAoGCCqGSM49BAMCA0gAMEUCIE2Zaqwj3xW+K9/dBPmGvlKT
+	bp+KTnC8cirWvJZNqjE/AiEAun0smHy5Xmf9Pp010T0/iFxUv7eK0cSBHcuxOBTe
+	aXU=
+	-----END X509 CRL-----
+	"""
+
+	// Expired CRL (nextUpdate: 2026-04-03T12:12:46Z - already passed)
+	static let expiredCRLPEM = """
+	-----BEGIN X509 CRL-----
+	MIG/MGcCAQEwCgYIKoZIzj0EAwIwEjEQMA4GA1UEAwwHVGVzdCBDQRcNMjYwNDAz
+	MTIxMjQ1WhcNMjYwNDAzMTIxMjQ2WjAUMBICAQIXDTI2MDQwMzEyMTIzN1qgDjAM
+	MAoGA1UdFAQDAgEDMAoGCCqGSM49BAMCA0gAMEUCIQDGu2YEaVYFqjUK5wcMxbFe
+	1PpLDgS+wyMPWkS4QM+3zgIgNJIoLbaRsGliNw9wC7QAX0Ok96z+h+NjiG1LSSMM
+	j0o=
+	-----END X509 CRL-----
+	"""
+
+	@Test("Parse valid CRL with no revoked certificates")
+	func parseEmptyCRL() throws {
+		let crl = try CRL(pemEncoded: Self.validEmptyCRLPEM)
+
+		#expect(crl.version == 1) // CRL v2
+		#expect(crl.issuer.description.contains("Test CA"))
+		#expect(crl.revokedSerials.isEmpty)
+
+		// thisUpdate: 2026-04-03, nextUpdate: 2036-03-31
+		#expect(crl.thisUpdate.year == 2026)
+		#expect(crl.thisUpdate.month == 4)
+		#expect(crl.thisUpdate.day == 3)
+		#expect(crl.nextUpdate.year == 2036)
+		#expect(crl.nextUpdate.month == 3)
+		#expect(crl.nextUpdate.day == 31)
+	}
+
+	@Test("Parse CRL with revoked certificate")
+	func parseRevokedCRL() throws {
+		let crl = try CRL(pemEncoded: Self.validRevokedCRLPEM)
+
+		#expect(crl.version == 1)
+		#expect(crl.issuer.description.contains("Test CA"))
+		#expect(crl.revokedSerials.count == 1)
+
+		// The revoked serial number is 02
+		let revokedSerial = try #require(crl.revokedSerials.first)
+		#expect(revokedSerial.serial.description.contains("2"))
+
+		// Revocation date should be 2026-04-03
+		#expect(revokedSerial.date.year == 2026)
+		#expect(revokedSerial.date.month == 4)
+		#expect(revokedSerial.date.day == 3)
+	}
+
+	@Test("Valid CRL passes validity check")
+	func validCRLIsValid() throws {
+		let crl = try CRL(pemEncoded: Self.validRevokedCRLPEM)
+		// nextUpdate is 2036, so this should be valid now
+		#expect(crl.isValid)
+	}
+
+	@Test("Expired CRL fails validity check")
+	func expiredCRLIsNotValid() throws {
+		let crl = try CRL(pemEncoded: Self.expiredCRLPEM)
+		// nextUpdate was 2026-04-03T12:12:46Z - already expired
+		#expect(!crl.isValid)
+	}
+
+	@Test("CRL field names match X.509 spec")
+	func fieldNamesMatchSpec() throws {
+		let crl = try CRL(pemEncoded: Self.validEmptyCRLPEM)
+		// Verify the fields are named according to X.509 CRL spec
+		_ = crl.thisUpdate  // was incorrectly named 'validity'
+		_ = crl.nextUpdate  // was incorrectly named 'subject'
+		_ = crl.version     // was incorrectly named 'serialNumber'
+		_ = crl.issuer
+		_ = crl.revokedSerials
+	}
+}

--- a/Tests/MdocSecurity18013Tests/InMemoryP256SecureArea.swift
+++ b/Tests/MdocSecurity18013Tests/InMemoryP256SecureArea.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Tests/MdocSecurity18013Tests/MdocCertificateTests.swift
+++ b/Tests/MdocSecurity18013Tests/MdocCertificateTests.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Tests/MdocSecurity18013Tests/MdocSecurity18013Tests.swift
+++ b/Tests/MdocSecurity18013Tests/MdocSecurity18013Tests.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Tests/MdocSecurity18013Tests/MdocSecurity18013Tests.swift
+++ b/Tests/MdocSecurity18013Tests/MdocSecurity18013Tests.swift
@@ -16,6 +16,7 @@ limitations under the License.
 import Foundation
 import Testing
 import SwiftCBOR
+import Security
 
 @testable import MdocDataModel18013
 @testable import MdocSecurity18013
@@ -110,9 +111,24 @@ struct MdocSecurity18013Tests {
 		for docR in dr.docRequests {
 			let mdocAuth = MdocReaderAuthentication(transcript: sessionEncr.sessionTranscript)
 			guard let readerAuthRawCBOR = docR.readerAuthRawCBOR else { continue }
-			let (b, message) = try mdocAuth.validateReaderAuth(readerAuthCBOR: readerAuthRawCBOR, readerAuthX5c: docR.readerCertificates, itemsRequestRawData: docR.itemsRequestRawData!)
+			let (b, message) = try mdocAuth.validateReaderAuth(readerAuthCBOR: readerAuthRawCBOR, readerAuthX5c: docR.readerCertificates, itemsRequestRawData: docR.itemsRequestRawData!, rootIaca: [])
 			#expect(!b, "Current date not in validity period of Certificate")
             print(message ?? "")
 		}
 	}
+
+    @Test("Validate readerAuth certificate chain trust with root IACA from annex D.4.11")
+    func validateReaderAuthCertificateTrustedWithRootIacaAnnexD411() throws {
+        let dr = try DeviceRequest(data: AnnexdTestData.request_d411.bytes)
+        let docR = try #require(dr.docRequests.first)
+        let leafData = try #require(docR.readerCertificates.first)
+        let leafCert = try #require(SecCertificateCreateWithData(nil, leafData as CFData))
+        let rootCert = try #require(SecCertificateCreateWithData(nil, AnnexdTestData.d54_readerRoot as CFData))
+        let rootIaca: [x5chain] = [[rootCert]]
+	    let mdocAuth = MdocReaderAuthentication(transcript: sessionEncr.sessionTranscript)
+        guard let readerAuthRawCBOR = docR.readerAuthRawCBOR else { continue }
+        let (b, message) = try mdocAuth.validateReaderAuth(readerAuthCBOR: readerAuthRawCBOR, readerAuthX5c: docR.readerCertificates, itemsRequestRawData: docR.itemsRequestRawData!, rootIaca: rootIaca)
+        #expect(!b, "Current date not in validity period of Certificate")
+        print(message ?? "")
+     }
 }

--- a/Tests/MdocSecurity18013Tests/MdocSecurity18013Tests.swift
+++ b/Tests/MdocSecurity18013Tests/MdocSecurity18013Tests.swift
@@ -119,16 +119,16 @@ struct MdocSecurity18013Tests {
 
     @Test("Validate readerAuth certificate chain trust with root IACA from annex D.4.11")
     func validateReaderAuthCertificateTrustedWithRootIacaAnnexD411() throws {
+		let (_,sessionEncr) = try #require(try makeSessionEncryptionFromAnnexData())
         let dr = try DeviceRequest(data: AnnexdTestData.request_d411.bytes)
-        let docR = try #require(dr.docRequests.first)
-        let leafData = try #require(docR.readerCertificates.first)
-        let leafCert = try #require(SecCertificateCreateWithData(nil, leafData as CFData))
         let rootCert = try #require(SecCertificateCreateWithData(nil, AnnexdTestData.d54_readerRoot as CFData))
         let rootIaca: [x5chain] = [[rootCert]]
-	    let mdocAuth = MdocReaderAuthentication(transcript: sessionEncr.sessionTranscript)
-        guard let readerAuthRawCBOR = docR.readerAuthRawCBOR else { continue }
-        let (b, message) = try mdocAuth.validateReaderAuth(readerAuthCBOR: readerAuthRawCBOR, readerAuthX5c: docR.readerCertificates, itemsRequestRawData: docR.itemsRequestRawData!, rootIaca: rootIaca)
-        #expect(!b, "Current date not in validity period of Certificate")
-        print(message ?? "")
-     }
+		for docR in dr.docRequests {
+			let mdocAuth = MdocReaderAuthentication(transcript: sessionEncr.sessionTranscript)
+			guard let readerAuthRawCBOR = docR.readerAuthRawCBOR else { continue }
+			let (b, message) = try mdocAuth.validateReaderAuth(readerAuthCBOR: readerAuthRawCBOR, readerAuthX5c: docR.readerCertificates, itemsRequestRawData: docR.itemsRequestRawData!, rootIaca: rootIaca)
+			#expect(!b, "Current date not in validity period of Certificate")
+            print(message ?? "")
+		}
+	}
 }

--- a/Tests/MdocSecurity18013Tests/MdocSecurityTestData.swift
+++ b/Tests/MdocSecurity18013Tests/MdocSecurityTestData.swift
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Tests/MdocSecurity18013Tests/MsoValidationTests.swift
+++ b/Tests/MdocSecurity18013Tests/MsoValidationTests.swift
@@ -16,11 +16,40 @@ limitations under the License.
 
 import Testing
 import Foundation
+import SwiftCBOR
+import X509
 @testable import MdocDataModel18013
 @testable import MdocSecurity18013
 
 @Suite("MSO Validation Tests")
 struct MsoValidationTests {
+
+    private func makeIssuerSignedFromAnnexD52() throws -> IssuerSigned {
+        let cbor = try #require(try CBOR.decode([UInt8](MdocSecurity18013Tests.AnnexdTestData.d52_issuerAuthCBOR)))
+        let issuerAuth = try IssuerAuth(cbor: cbor)
+        return IssuerSigned(issuerNameSpaces: nil, issuerAuth: issuerAuth)
+    }
+
+    private func cloneIssuerSigned(_ issuerSigned: IssuerSigned, with validityInfo: ValidityInfo) -> IssuerSigned {
+        let mso = issuerSigned.issuerAuth.mso
+        let msoUpdated = MobileSecurityObject(
+            version: mso.version,
+            digestAlgorithm: mso.digestAlgorithm,
+            valueDigests: mso.valueDigests,
+            deviceKey: mso.deviceKeyInfo.deviceKey,
+            docType: mso.docType,
+            validityInfo: validityInfo
+        )
+        let issuerAuthUpdated = IssuerAuth(
+            mso: msoUpdated,
+            msoRawData: issuerSigned.issuerAuth.msoRawData,
+            verifyAlgorithm: issuerSigned.issuerAuth.verifyAlgorithm,
+            signature: issuerSigned.issuerAuth.signature,
+            x5chain: issuerSigned.issuerAuth.x5chain,
+            statusIdentifier: issuerSigned.issuerAuth.statusIdentifier
+        )
+        return IssuerSigned(issuerNameSpaces: issuerSigned.issuerNameSpaces, issuerAuth: issuerAuthUpdated)
+    }
 
     @Test("MSO verifications run successfully")
     func testMsoValidations() async throws {
@@ -37,6 +66,64 @@ struct MsoValidationTests {
                 errors.forEach { print($0.errorDescription ?? "Unknown error") }
             default: print(error.errorDescription ?? "Unknown error") }
         }
+    }
+
+    @Test("MSO validity rejects equal validFrom and validUntil")
+    func msoValidationRejectsEqualValidFromAndValidUntil() throws {
+        let issuerSigned = try makeIssuerSignedFromAnnexD52()
+        let mso = issuerSigned.issuerAuth.mso
+        let equalDatesValidityInfo = ValidityInfo(
+            signed: mso.validityInfo.signed,
+            validFrom: mso.validityInfo.validFrom,
+            validUntil: mso.validityInfo.validFrom,
+            expectedUpdate: mso.validityInfo.expectedUpdate
+        )
+        let issuerSignedWithEqualDates = cloneIssuerSigned(issuerSigned, with: equalDatesValidityInfo)
+        let errors = issuerSignedWithEqualDates.validateValidityInfo(mso: issuerSignedWithEqualDates.issuerAuth.mso) ?? []
+        #expect(errors.contains(where: { error in
+            if case .validityInfo(let reason) = error {
+                return reason.contains("strictly earlier")
+            }
+            return false
+        }))
+    }
+
+    @Test("MSO validity can reject validUntil beyond certificate expiry")
+    func msoValidationRejectsValidUntilAfterCertificateExpiryWhenConfigured() throws {
+        let issuerSigned = try makeIssuerSignedFromAnnexD52()
+        let dsCert = try X509.Certificate(derEncoded: issuerSigned.issuerAuth.x5chain[0])
+        let mso = issuerSigned.issuerAuth.mso
+        let overflowDate = dsCert.notValidAfter.addingTimeInterval(60)
+        let isoOverflowDate = ISO8601DateFormatter().string(from: overflowDate)
+        let validityInfo = ValidityInfo(
+            signed: mso.validityInfo.signed,
+            validFrom: mso.validityInfo.validFrom,
+            validUntil: isoOverflowDate,
+            expectedUpdate: mso.validityInfo.expectedUpdate
+        )
+        let issuerSignedOverflow = cloneIssuerSigned(issuerSigned, with: validityInfo)
+
+        let relaxedErrors = issuerSignedOverflow.validateValidityInfo(
+            mso: issuerSignedOverflow.issuerAuth.mso,
+            options: .init(rejectIfValidUntilExceedsCertificateValidity: false)
+        ) ?? []
+        #expect(!relaxedErrors.contains(where: { error in
+            if case .validityInfo(let reason) = error {
+                return reason.contains("exceeds certificate validity")
+            }
+            return false
+        }))
+
+        let strictErrors = issuerSignedOverflow.validateValidityInfo(
+            mso: issuerSignedOverflow.issuerAuth.mso,
+            options: .init(rejectIfValidUntilExceedsCertificateValidity: true)
+        ) ?? []
+        #expect(strictErrors.contains(where: { error in
+            if case .validityInfo(let reason) = error {
+                return reason.contains("exceeds certificate validity")
+            }
+            return false
+        }))
     }
 
 

--- a/Tests/MdocSecurity18013Tests/MsoValidationTests.swift
+++ b/Tests/MdocSecurity18013Tests/MsoValidationTests.swift
@@ -1,5 +1,5 @@
     /*
-Copyright (c) 2023 European Commission
+Copyright (c) 2026 European Commission
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Tests/MdocSecurity18013Tests/SampleDataSecureArea.swift
+++ b/Tests/MdocSecurity18013Tests/SampleDataSecureArea.swift
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2023 European Commission
+ Copyright (c) 2026 European Commission
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Tests/MdocSecurity18013Tests/SampleDataSecureArea.swift
+++ b/Tests/MdocSecurity18013Tests/SampleDataSecureArea.swift
@@ -61,7 +61,8 @@ actor SampleDataSecureArea: SecureArea {
         default: throw SecureAreaError("Unsupported curve \(curve)")
         }
         let kbi = KeyBatchInfo(secureAreaName: Self.name, crv: curve, usedCounts: [0], credentialPolicy: .rotateUse)
-        try await storage.writeKeyInfo(id: id, dict: [kSecValueData as String: kbi.toData() ?? Data(), kSecAttrDescription as String: curve.jwkName.data(using: .utf8)!])
+        guard let kbiData = kbi.toData() else { throw SecureAreaError("Failed to encode KeyBatchInfo") }
+        try await storage.writeKeyInfo(id: id, dict: [kSecValueData as String: kbiData, kSecAttrDescription as String: curve.jwkName.data(using: .utf8)!])
         try await storage.writeKeyDataBatch(id: id, startIndex: 0, dicts: [[kSecValueData as String: x963Priv]], keyOptions: keyOptions)
         return [CoseKey(crv: curve, x963Representation: x963Pub)]
     }

--- a/Tests/MdocSecurity18013Tests/SampleDataSecureArea.swift
+++ b/Tests/MdocSecurity18013Tests/SampleDataSecureArea.swift
@@ -18,31 +18,34 @@ import Foundation
 @preconcurrency import CryptoKit
 import Security
 import MdocDataModel18013
-/// Sample data secure area
-///
-/// This SecureArea implementation uses iOS Cryptokit framework
-public actor SampleDataSecureArea: SecureArea {
+@testable import MdocSecurity18013
 
-    public let storage: any SecureKeyStorage
+/// Sample data secure area (test-only)
+///
+/// This SecureArea implementation uses iOS Cryptokit framework and allows
+/// injecting a predetermined private key for testing purposes.
+actor SampleDataSecureArea: SecureArea {
+
+    let storage: any SecureKeyStorage
     private var x963Key: Data?
 
-    public init(storage: any SecureKeyStorage, x963Key: Data? = nil) {
+    init(storage: any SecureKeyStorage, x963Key: Data? = nil) {
         self.storage = storage
         self.x963Key = x963Key
     }
 
     /// Sets the x963 key representation for use in key creation.
     /// - Parameter key: The x963 representation of the private key.
-    public func setX963Key(_ key: Data?) {
+    func setX963Key(_ key: Data?) {
         self.x963Key = key
     }
-    nonisolated public static func create(storage: any MdocDataModel18013.SecureKeyStorage) -> SampleDataSecureArea {
+    nonisolated static func create(storage: any MdocDataModel18013.SecureKeyStorage) -> SampleDataSecureArea {
         SampleDataSecureArea(storage: storage)
     }
-    public static var supportedEcCurves: [CoseEcCurve] { [.P256, .P384, .P521] }
-    public func getStorage() async -> any MdocDataModel18013.SecureKeyStorage { storage }
+    static var supportedEcCurves: [CoseEcCurve] { [.P256, .P384, .P521] }
+    func getStorage() async -> any MdocDataModel18013.SecureKeyStorage { storage }
 
-    public func createKeyBatch(id: String, credentialOptions: CredentialOptions, keyOptions: KeyOptions?) async throws -> [CoseKey] {
+    func createKeyBatch(id: String, credentialOptions: CredentialOptions, keyOptions: KeyOptions?) async throws -> [CoseKey] {
         let x963Priv: Data; let x963Pub: Data
         let curve = keyOptions?.curve ?? .P256
         switch curve {
@@ -62,34 +65,31 @@ public actor SampleDataSecureArea: SecureArea {
         try await storage.writeKeyDataBatch(id: id, startIndex: 0, dicts: [[kSecValueData as String: x963Priv]], keyOptions: keyOptions)
         return [CoseKey(crv: curve, x963Representation: x963Pub)]
     }
-    
-    public func getPublicKey(id: String, index: Int, curve: CoseEcCurve) async throws -> CoseKey {
+
+    func getPublicKey(id: String, index: Int, curve: CoseEcCurve) async throws -> CoseKey {
         let softwareSA = SoftwareSecureArea(storage: storage)
         return try await softwareSA.getPublicKey(id: id, index: index, curve: curve)
     }
 
-    /// delete key
-    public func deleteKeyBatch(id: String, startIndex: Int, batchSize: Int) async throws {
+    func deleteKeyBatch(id: String, startIndex: Int, batchSize: Int) async throws {
         try await storage.deleteKeyBatch(id: id, startIndex: startIndex, batchSize: batchSize)
     }
-    /// compute signature
-    public func signature(id: String, index: Int, algorithm: SigningAlgorithm, dataToSign: Data, unlockData: Data?) async throws -> Data {
+
+    func signature(id: String, index: Int, algorithm: SigningAlgorithm, dataToSign: Data, unlockData: Data?) async throws -> Data {
         let softwareSA = SoftwareSecureArea(storage: storage)
         return try await softwareSA.signature(id: id, index: index, algorithm: algorithm, dataToSign: dataToSign, unlockData: unlockData)
     }
 
-    /// make shared secret with other public key
-    public func keyAgreement(id: String, index: Int, publicKey: CoseKey, unlockData: Data?) async throws -> SharedSecret {
+    func keyAgreement(id: String, index: Int, publicKey: CoseKey, unlockData: Data?) async throws -> SharedSecret {
         let softwareSA = SoftwareSecureArea(storage: storage)
         return try await softwareSA.keyAgreement(id: id, index: index, publicKey: publicKey, unlockData: unlockData)
     }
 
-    /// returns information about the key with the given key
-    public func getKeyBatchInfo(id: String) async throws -> KeyBatchInfo {
+    func getKeyBatchInfo(id: String) async throws -> KeyBatchInfo {
         let softwareSA = SoftwareSecureArea(storage: storage)
         return try await softwareSA.getKeyBatchInfo(id: id)
     }
-    public func deleteKeyInfo(id: String) async throws {
+    func deleteKeyInfo(id: String) async throws {
         try await storage.deleteKeyInfo(id: id)
     }
 }


### PR DESCRIPTION
Enhance the security of the library by moving `SampleDataSecureArea` to the test target, ensuring CRL signatures are verified, and handling revoked serial decoding errors more transparently. Update the `validateReaderAuth` method to require root certificates, and introduce configuration options for MsoValidation to comply with ISO standards. Improve certificate extension validation by enforcing checks for duplicates and forbidden critical extensions. Additionally, refine the `SessionTranscript` type to ensure compliance with specifications and rename the counter method to reflect its big-endian requirement.

Fixes #79, #80, #77, #76, #73, #75, #74, #82