### PR TITLE
Update the `eudi-lib-ios-iso18013-data-model` dependency to version 0.15.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "0a1823d10faaeebf675a3013e4eb7b0dc81f9775197748eed7fad924b81d5689",
+  "originHash" : "c4f7dc248badcc876ea44a486229c399802fb7e395fea2c45bcce30d12ccf950",
   "pins" : [
     {
       "identity" : "eudi-lib-ios-iso18013-data-model",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "87b0059b1da7b6c195fe78875637f7130cb4ac54",
-        "version" : "0.14.0"
+        "revision" : "2e13a0e52993bb5084a07129e5cdd9491949b017",
+        "version" : "0.15.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         // .package(path: "../eudi-lib-ios-iso18013-data-model"),
-        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git", exact: "0.14.0"),
+        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git", exact: "0.15.0"),
         .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMajor(from: "1.0.0")),
     ],
     targets: [

--- a/Sources/MdocSecurity18013/SessionEncryption/SessionEncryption.swift
+++ b/Sources/MdocSecurity18013/SessionEncryption/SessionEncryption.swift
@@ -105,7 +105,6 @@ public struct SessionEncryption: Sendable {
 
 	/// Session keys are derived using ECKA-DH (Elliptic Curve Key Agreement Algorithm – Diffie-Hellman) as defined in BSI TR-03111
 	mutating func makeKeyAgreementAndDeriveSessionKey(isEncrypt: Bool) async throws -> SymmetricKey  {
-        if sessionKeys.privateKey.privateKeyId == nil { try await sessionKeys.privateKey.makeKey(curve: type(of: sessionKeys.privateKey.secureArea).defaultEcCurve) }
 		let sharedKey = try await sessionKeys.makeEckaDHAgreement()
 		let symmetricKey = try Self.HMACKeyDerivationFunction(sharedSecret: sharedKey, salt: sessionTranscriptBytes, info: getInfo(isEncrypt: isEncrypt).data(using: .utf8)!)
 		return symmetricKey

--- a/Tests/MdocSecurity18013Tests/InMemoryP256SecureArea.swift
+++ b/Tests/MdocSecurity18013Tests/InMemoryP256SecureArea.swift
@@ -95,12 +95,12 @@ public actor DummySecureKeyStorage: MdocDataModel18013.SecureKeyStorage {
 
 extension MdocDataModel18013.CoseKeyPrivate {
   // decode cbor string
-    public init?(p256data base64: String) {
+      public init?(p256data base64: String) {
         guard let d = Data(base64Encoded: base64), let obj = try? CBOR.decode([UInt8](d)), let coseKey = try? CoseKey(cbor: obj), let cd = obj[-4], case let CBOR.byteString(rd) = cd else { return nil }
         let keyData = NSMutableData(bytes: [0x04], length: [0x04].count)
-        keyData.append(Data(coseKey.x)); keyData.append(Data(coseKey.y)); keyData.append(Data(rd))
+        keyData.append(Data(coseKey.x)); keyData.append(Data(coseKey.y));  keyData.append(Data(rd))
         let sampleSA = InMemoryP256SecureArea(storage: DummySecureKeyStorage(), x963Key: keyData as Data)
-        self.init(secureArea: sampleSA)
+        self.init(privateKeyId: UUID().uuidString, index: 0, secureArea: sampleSA, curve: .P256)
     }
 
     /// Create a COSE_Key from Elliptic Curve paramters of the private key.
@@ -113,7 +113,6 @@ extension MdocDataModel18013.CoseKeyPrivate {
         let keyData = NSMutableData(bytes: [0x04], length: [0x04].count)
         keyData.append(Data(x)); keyData.append(Data(y)); keyData.append(Data(d))
         let sampleSA = InMemoryP256SecureArea(storage: DummySecureKeyStorage(), x963Key: keyData as Data)
-        self.init(secureArea: sampleSA)
-        self.key = CoseKey(x: x, y: y, crv: crv)
+        self.init(privateKeyId: UUID().uuidString, index: 0, secureArea: sampleSA, curve: .P256)
     }
 }

--- a/Tests/MdocSecurity18013Tests/InMemoryP256SecureArea.swift
+++ b/Tests/MdocSecurity18013Tests/InMemoryP256SecureArea.swift
@@ -28,6 +28,7 @@ public actor InMemoryP256SecureArea: SecureArea {
     init(storage: any MdocDataModel18013.SecureKeyStorage, x963Key: Data? = nil) {
         self.storage = storage
         self.x963Key = x963Key
+        key = if let x963Key { try! P256.Signing.PrivateKey(x963Representation: x963Key) } else { P256.Signing.PrivateKey() }
     }
 
     /// Sets the x963 key representation for use in key creation.
@@ -42,7 +43,7 @@ public actor InMemoryP256SecureArea: SecureArea {
 
     public func getStorage() async -> any MdocDataModel18013.SecureKeyStorage { storage }
 
-    public func createKey(id: String, index: Int, keyOptions: MdocDataModel18013.KeyOptions?) async throws -> MdocDataModel18013.CoseKey {
+    public func createKey(id: String, index: Int, keyOptions: MdocDataModel18013.KeyOptions?) throws -> MdocDataModel18013.CoseKey {
         key = if let x963Key { try P256.Signing.PrivateKey(x963Representation: x963Key) } else { P256.Signing.PrivateKey() }
         guard SecKeyCreateWithData(key.x963Representation as NSData, [kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom, kSecAttrKeyClass: kSecAttrKeyClassPrivate] as NSDictionary, nil) != nil else {  throw NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey : "Error creating private key"])  }
         return CoseKey(crv: .P256, x963Representation: key.publicKey.x963Representation)

--- a/Tests/MdocSecurity18013Tests/MdocSecurity18013Tests.swift
+++ b/Tests/MdocSecurity18013Tests/MdocSecurity18013Tests.swift
@@ -80,8 +80,9 @@ struct MdocSecurity18013Tests {
     @Test("Compute DeviceAuthenticationBytes and MacStructure from annex D.5.3")
     func computeDeviceAuthenticationBytesAndMacStructureAnnexD53() async throws {
         let (_,sessionEncr) = try #require(try makeSessionEncryptionFromAnnexData())
-        var authKeys = CoseKeyExchange(publicKey: Self.AnnexdTestData.d51_ephReaderKey.key, privateKey: Self.AnnexdTestData.d53_deviceKey)
-        if authKeys.privateKey.privateKeyId == nil { try await authKeys.privateKey.makeKey(curve: CoseEcCurve.P256) }
+        var ephReaderKey = Self.AnnexdTestData.d51_ephReaderKey
+        let key = try await ephReaderKey.key
+        let authKeys = CoseKeyExchange(publicKey: key, privateKey: Self.AnnexdTestData.d53_deviceKey)
         let mdocAuth = MdocAuthentication(sessionTranscript: sessionEncr.sessionTranscript, authKeys: authKeys)
         let da = DeviceAuthentication(sessionTranscript: mdocAuth.sessionTranscript, docType: "org.iso.18013.5.1.mDL", deviceNameSpacesRawData: [0xA0])
         #expect(Data(da.toCBOR(options: CBOROptions()).taggedEncoded.encode(options: CBOROptions())) == AnnexdTestData.d53_deviceAuthDeviceAuthenticationBytes)
@@ -93,8 +94,9 @@ struct MdocSecurity18013Tests {
     @Test("Compute deviceAuth CBOR data")
     func computeDeviceAuthCBORData() async throws {
         let (_,sessionEncr) = try #require(try makeSessionEncryptionFromAnnexData())
-        var authKeys = CoseKeyExchange(publicKey: Self.AnnexdTestData.d51_ephReaderKey.key, privateKey: Self.AnnexdTestData.d53_deviceKey)
-        if authKeys.privateKey.privateKeyId == nil { try await authKeys.privateKey.makeKey(curve: CoseEcCurve.P256) }
+        var ephReaderKey = Self.AnnexdTestData.d51_ephReaderKey
+        let key = try await ephReaderKey.key
+        let authKeys = CoseKeyExchange(publicKey: key, privateKey: Self.AnnexdTestData.d53_deviceKey)
         let mdocAuth = MdocAuthentication(sessionTranscript: sessionEncr.sessionTranscript, authKeys: authKeys)
 		let bUseDeviceSign = UserDefaults.standard.bool(forKey: "PreferDeviceSignature")
         let dAuthO = try await mdocAuth.getDeviceAuthForTransfer(docType: "org.iso.18013.5.1.mDL", deviceNameSpacesRawData: [0xA0],


### PR DESCRIPTION
Update the `eudi-lib-ios-iso18013-data-model` dependency to version 0.15.0 and adjust the initialization of `CoseKeyPrivate` to include `privateKeyId` and curve parameters.