### PR TITLE
Update eudi-lib-ios-iso18013-data-model package

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "3746fa86279b0bf4da00ae5e6d74ec3c32a1ee73fda0f789d7d0197e5b310050",
+  "originHash" : "31ecfbceba781b2bc5b6f9137331816247be06f4e4fa624c0f7b081e33d41594",
   "pins" : [
     {
       "identity" : "eudi-lib-ios-iso18013-data-model",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
+      "location" : "https://github.com/beyonkuhre/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "fa8854523d7e71aba87de0f2540afc74adbb15bc",
-        "version" : "0.20.2"
+        "branch" : "feat/key-authorizations",
+        "revision" : "dddf6938dbb69a814542ce14071f9365dc1d507d"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "03cc312c2c933ed87abace34044a5dff7a3117c1",
-        "version" : "1.5.0"
+        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
+        "version" : "1.5.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/beyonkuhre/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
         "branch" : "feat/key-authorizations",
-        "revision" : "dddf6938dbb69a814542ce14071f9365dc1d507d"
+        "revision" : "80cbfe9866da7d5ae39b3a96f9ed9eda48e2173c"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,10 +13,10 @@ let package = Package(
             targets: ["MdocSecurity18013"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/beyonkuhre/eudi-lib-ios-iso18013-data-model.git", branch: "feat/key-authorizations"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
+        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git", from: "0.21.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.13.1"),
         .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMajor(from: "1.0.0")),
-		.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+		.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.5.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["MdocSecurity18013"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git", exact: "0.20.2"),
+        .package(url: "https://github.com/beyonkuhre/eudi-lib-ios-iso18013-data-model.git", branch: "feat/key-authorizations"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
         .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMajor(from: "1.0.0")),
 		.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Initialized from the session trascript object, the device private key and the re
  
 ```swift
 let mdocAuth = MdocAuthentication(transcript: sessionEncr.transcript, authKeys: authKeys)
-let deviceAuth = try mdocAuth.getDeviceAuthForTransfer(docType: "org.iso.18013.5.1.mDL", deviceNameSpacesRawData: [0xA0], bUseDeviceSign: bUseDeviceSign)!
+let deviceAuth = try mdocAuth.getDeviceAuthForTransfer(docType: "org.iso.18013.5.1.mDL", dauthMethod: bUseDeviceSign ? .deviceSignature : .deviceMac, deviceNameSpaces: nil, unlockData: nil)!
 let ourDeviceAuthCBORbytes = deviceAuth.encode(options: CBOROptions())
 ```
 

--- a/Sources/MdocSecurity18013/MdocAuthentication/DeviceAuthentication.swift
+++ b/Sources/MdocSecurity18013/MdocAuthentication/DeviceAuthentication.swift
@@ -27,7 +27,7 @@ import MdocDataModel18013
   public struct DeviceAuthentication: Sendable {
     let sessionTranscript: SessionTranscript
     let docType: String
-    let deviceNameSpacesRawData: [UInt8]
+    let deviceNameSpaces: DeviceNameSpaces?
   }
 
   extension DeviceAuthentication: CBOREncodable {
@@ -35,8 +35,8 @@ import MdocDataModel18013
         let authenticationLabel = CBOR.utf8String("DeviceAuthentication")
         let transcriptCbor = sessionTranscript.toCBOR(options: options)
         let documentType = CBOR.utf8String(docType)
-        let taggedNameSpaces = deviceNameSpacesRawData.taggedEncoded
-        return .array([authenticationLabel, transcriptCbor, documentType, taggedNameSpaces])
+        let nameSpaces = deviceNameSpaces != nil ? deviceNameSpaces.encode(options: options) : [0xA0]
+        return .array([authenticationLabel, transcriptCbor, documentType, nameSpaces.taggedEncoded])
       }
   }
 

--- a/Sources/MdocSecurity18013/MdocAuthentication/MdocAuthentication.swift
+++ b/Sources/MdocSecurity18013/MdocAuthentication/MdocAuthentication.swift
@@ -65,14 +65,14 @@ public struct MdocAuthentication: Sendable {
 	/// - Returns: DeviceAuth instance
     public func getDeviceAuthForTransfer(
         docType: String,
-        deviceNameSpacesRawData: [UInt8] = [0xA0],
         dauthMethod: DeviceAuthMethod,
+        deviceNameSpaces: DeviceNameSpaces?,
         unlockData: Data?
     ) async throws -> DeviceAuth? {
 		let deviceAuthentication = DeviceAuthentication(
 			sessionTranscript: sessionTranscript,
 			docType: docType,
-			deviceNameSpacesRawData: deviceNameSpacesRawData
+			deviceNameSpaces: deviceNameSpaces
 		)
 		let contentBytes = deviceAuthentication.toCBOR(options: CBOROptions())
 			.taggedEncoded

--- a/Tests/MdocSecurity18013Tests/MdocSecurity18013Tests.swift
+++ b/Tests/MdocSecurity18013Tests/MdocSecurity18013Tests.swift
@@ -84,7 +84,7 @@ struct MdocSecurity18013Tests {
         let key = try await ephReaderKey.key
         let authKeys = CoseKeyExchange(publicKey: key, privateKey: Self.AnnexdTestData.d53_deviceKey)
         let mdocAuth = MdocAuthentication(sessionTranscript: sessionEncr.sessionTranscript, authKeys: authKeys)
-        let da = DeviceAuthentication(sessionTranscript: mdocAuth.sessionTranscript, docType: "org.iso.18013.5.1.mDL", deviceNameSpacesRawData: [0xA0])
+        let da = DeviceAuthentication(sessionTranscript: mdocAuth.sessionTranscript, docType: "org.iso.18013.5.1.mDL", deviceNameSpaces: nil)
         #expect(Data(da.toCBOR(options: CBOROptions()).taggedEncoded.encode(options: CBOROptions())) == AnnexdTestData.d53_deviceAuthDeviceAuthenticationBytes)
         let coseIn = Cose(type: .mac0, algorithm: Cose.MacAlgorithm.hmac256.rawValue, payloadData: AnnexdTestData.d53_deviceAuthDeviceAuthenticationBytes)
 		let dataToSign = try #require(coseIn.signatureStruct)
@@ -99,8 +99,11 @@ struct MdocSecurity18013Tests {
         let authKeys = CoseKeyExchange(publicKey: key, privateKey: Self.AnnexdTestData.d53_deviceKey)
         let mdocAuth = MdocAuthentication(sessionTranscript: sessionEncr.sessionTranscript, authKeys: authKeys)
 		let bUseDeviceSign = UserDefaults.standard.bool(forKey: "PreferDeviceSignature")
-        let dAuthO = try await mdocAuth.getDeviceAuthForTransfer(docType: "org.iso.18013.5.1.mDL", deviceNameSpacesRawData: [0xA0],
-            dauthMethod: bUseDeviceSign ? .deviceSignature : .deviceMac, unlockData: nil)
+        let dAuthO = try await mdocAuth.getDeviceAuthForTransfer(
+            docType: "org.iso.18013.5.1.mDL",
+            dauthMethod: bUseDeviceSign ? .deviceSignature : .deviceMac,
+            deviceNameSpaces: nil,
+            unlockData: nil)
 		let deviceAuth = try #require(dAuthO)
         let ourDeviceAuthCBORbytes = deviceAuth.encode(options: CBOROptions())
         #expect(Data(ourDeviceAuthCBORbytes) == AnnexdTestData.d53_deviceAuthCBORdata)


### PR DESCRIPTION
Update eudi-lib-ios-iso18013-data-model package

Changes needed to implement transaction data for mso_mdoc credentials: https://github.com/eu-digital-identity-wallet/eudi-lib-ios-wallet-kit/issues/377