### PR TITLE
Update CRL revocation handling with RevocationPolicy enum

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "31ecfbceba781b2bc5b6f9137331816247be06f4e4fa624c0f7b081e33d41594",
+  "originHash" : "5c5520a44ffba87fb5f5bbc75a99b3b03238a6bb3507c77ec2a2b84b2f3a776a",
   "pins" : [
     {
       "identity" : "eudi-lib-ios-iso18013-data-model",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/beyonkuhre/eudi-lib-ios-iso18013-data-model.git",
+      "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "branch" : "feat/key-authorizations",
-        "revision" : "80cbfe9866da7d5ae39b3a96f9ed9eda48e2173c"
+        "revision" : "4f0dce084eab1d4c62d770af5c87a0f4e6c6e789",
+        "version" : "0.22.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
-        "version" : "1.10.1"
+        "revision" : "92448c359f00ebe36ae97d3bd9086f13c7692b5a",
+        "version" : "1.13.2"
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Currently the mdoc side is implemented (verification of reader-auth CBOR data)
 ```swift
 let mdocAuth = MdocReaderAuthentication(transcript: sessionEncr.transcript)
 guard let readerAuthRawCBOR = docR.readerAuthRawCBOR else { continue }
-let b = try mdocAuth.validateReaderAuth(readerAuthCBOR: readerAuthRawCBOR, readerAuthCertificate: docR.readerCertificate!, itemsRequestRawData: docR.itemsRequestRawData!)
+let b = try mdocAuth.validateReaderAuth(readerAuthCBOR: readerAuthRawCBOR, readerAuthX5c: docR.readerCertificates, itemsRequestRawData: docR.itemsRequestRawData!, rootIaca: [], crlRevocationPolicy: .hardFail)
 ```
 
 ## Dependencies (to other libs)

--- a/Sources/MdocSecurity18013/MdocReaderAuthentication/MdocReaderAuthentication.swift
+++ b/Sources/MdocSecurity18013/MdocReaderAuthentication/MdocReaderAuthentication.swift
@@ -39,7 +39,8 @@ public struct MdocReaderAuthentication: Sendable {
 		readerAuthCBOR: CBOR,
 		readerAuthX5c: [Data],
 		itemsRequestRawData: [UInt8],
-		rootIaca: [x5chain]
+		rootIaca: [x5chain],
+		crlRevocationPolicy: RevocationPolicy
 	) throws -> (Bool, String?) {
 		let readerAuthentication = ReaderAuthentication(
 			sessionTranscript: transcript,
@@ -66,6 +67,7 @@ public struct MdocReaderAuthentication: Sendable {
 		let certificateValidation = SecurityHelpers.isMdocX5cValid(
 			secCerts: secCerts,
 			usage: .mdocReaderAuth,
+			revocationPolicy: crlRevocationPolicy,
 			rootIaca: rootIaca
 		)
 		if !certificateValidation.isValid {

--- a/Sources/MdocSecurity18013/x509certificates/RevocationPolicy.swift
+++ b/Sources/MdocSecurity18013/x509certificates/RevocationPolicy.swift
@@ -1,0 +1,21 @@
+/*
+Copyright (c) 2026 European Commission
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// CRL Revocation Policy
+public enum RevocationPolicy {
+    case warning
+    case hardFail
+}

--- a/Sources/MdocSecurity18013/x509certificates/RevocationPolicy.swift
+++ b/Sources/MdocSecurity18013/x509certificates/RevocationPolicy.swift
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 /// CRL Revocation Policy
-public enum RevocationPolicy {
+public enum RevocationPolicy: Sendable {
     case warning
     case hardFail
 }

--- a/Sources/MdocSecurity18013/x509certificates/SecurityHelpers.swift
+++ b/Sources/MdocSecurity18013/x509certificates/SecurityHelpers.swift
@@ -113,11 +113,11 @@ public class SecurityHelpers {
 						return (false, ["Issuer data rfc822Name or uniformResourceIdentifier do not match with root cert."], nil)
 					}
 				}
-				let bs = fetchCRLSerialNumbers(x509root, messages: &messages)
-				if !bs.isEmpty {
-					if bs.contains(x509cert.serialNumber) { return (false, ["Revoked issued Certificate"], rootCert)}
-					if bs.contains(x509root.serialNumber) { return (false,["Revoked Root Certificate"], rootCert)}
+				guard let bs = fetchCRLSerialNumbers(x509root, revocationPolicy: .hardFail, messages: &messages) else {
+					return (false, ["CRL revocation check failed"], nil)
 				}
+				if bs.contains(x509cert.serialNumber) { return (false, ["Revoked issued Certificate"], rootCert)}
+				if bs.contains(x509root.serialNumber) { return (false,["Revoked Root Certificate"], rootCert)}
 				return (true, messages, rootCert)
 			}
 		} // next
@@ -180,30 +180,45 @@ public class SecurityHelpers {
 
 	public static func fetchCRLSerialNumbers(
 		_ x509root: X509.Certificate,
+        revocationPolicy: RevocationPolicy,
 		messages: inout [String]
-	) -> [Certificate.SerialNumber] {
+	) -> [Certificate.SerialNumber]? {
 		var bs = [Certificate.SerialNumber]()
 		if let crlDistributionExtension = x509root.extensions[oid: .X509ExtensionID.cRLDistributionPoints],
 		   let crlDistributions = try? CRLDistributions(derEncoded: crlDistributionExtension.value) {
 			for crl in crlDistributions.crls {
-				guard let crlUrl = URL(string: crl.distributionPoint) else { continue }
-				guard let crlData = try? Data(contentsOf: crlUrl) else { continue }
+				guard let crlUrl = URL(string: crl.distributionPoint) else {
+					if revocationPolicy == .hardFail { return nil }
+					continue
+				}
+				guard let crlData = try? Data(contentsOf: crlUrl) else {
+					if revocationPolicy == .hardFail { return nil }
+					continue
+				}
 				let crl: CRL
 				if let pemString = String(data: crlData, encoding: .utf8), pemString.contains("-----BEGIN") {
-					guard let pemCrl = try? CRL(pemEncoded: pemString) else { continue }
+					guard let pemCrl = try? CRL(pemEncoded: pemString) else {
+						if revocationPolicy == .hardFail { return nil }
+						continue
+					}
 					crl = pemCrl
 				} else {
-					guard let derCrl = try? CRL(derEncoded: Array(crlData)) else { continue }
+					guard let derCrl = try? CRL(derEncoded: Array(crlData)) else {
+						if revocationPolicy == .hardFail { return nil }
+						continue
+					}
 					crl = derCrl
 				}
 				guard crl.isValid else {
 					let validityWindow = "thisUpdate: \(crl.thisUpdate), nextUpdate: \(crl.nextUpdate)"
 					let errorMessage = "CRL from \(crlUrl) is not within its validity period (\(validityWindow))"
 					messages.append(errorMessage)
+					if revocationPolicy == .hardFail { return nil }
 					continue
 				}
 				guard crl.verifySignature(issuer: x509root) else {
 					messages.append("CRL from \(crlUrl) has an invalid signature")
+					if revocationPolicy == .hardFail { return nil }
 					continue
 				}
 				bs.append(contentsOf: crl.revokedSerials.map(\.serial))

--- a/Sources/MdocSecurity18013/x509certificates/SecurityHelpers.swift
+++ b/Sources/MdocSecurity18013/x509certificates/SecurityHelpers.swift
@@ -53,7 +53,8 @@ public class SecurityHelpers {
 	public static func isMdocX5cValid(
 		secCerts: x5chain,
 		usage: CertificateUsage,
-		rootIaca: [x5chain]
+		revocationPolicy: RevocationPolicy,
+		rootIaca: [x5chain],
 	) -> (isValid: Bool, validationMessages: [String], rootCert: SecCertificate?) {
 		guard let secCert = secCerts.first else { return (false, ["Certificate not found"], nil) }
 		// convert to swift-certificates object
@@ -113,7 +114,7 @@ public class SecurityHelpers {
 						return (false, ["Issuer data rfc822Name or uniformResourceIdentifier do not match with root cert."], nil)
 					}
 				}
-				guard let bs = fetchCRLSerialNumbers(x509root, revocationPolicy: .hardFail, messages: &messages) else {
+				guard let bs = fetchCRLSerialNumbers(x509root, revocationPolicy: revocationPolicy, messages: &messages) else {
 					return (false, ["CRL revocation check failed"], nil)
 				}
 				if bs.contains(x509cert.serialNumber) { return (false, ["Revoked issued Certificate"], rootCert)}

--- a/Tests/MdocSecurity18013Tests/CRLTests.swift
+++ b/Tests/MdocSecurity18013Tests/CRLTests.swift
@@ -81,7 +81,7 @@ struct CRLTests {
 		#expect(crl.verifySignature(issuer: x509root), "CRL signature must be valid against issuing CA")
 		// Also verify via fetchCRLSerialNumbers which integrates all checks
 		var messages = [String]()
-		let serials = SecurityHelpers.fetchCRLSerialNumbers(x509root, messages: &messages)
+		let serials = SecurityHelpers.fetchCRLSerialNumbers(x509root, revocationPolicy: .warning, messages: &messages) ?? []
 		#expect(!messages.contains(where: { $0.contains("invalid signature") }), "fetchCRLSerialNumbers should not report signature errors: \(messages)")
 		print("Fetched \(serials.count) revoked serial(s), messages: \(messages)")
 	}

--- a/Tests/MdocSecurity18013Tests/MdocCertificateTests.swift
+++ b/Tests/MdocSecurity18013Tests/MdocCertificateTests.swift
@@ -63,7 +63,7 @@ struct CertificateHandlingTests {
 	func isMdocX5cValidNoRoots() throws {
 		let leafCert = try #require(eudiIaca.first)
 		let (isValid, messages, rootCert) = SecurityHelpers.isMdocX5cValid(
-			secCerts: [leafCert], usage: .mdocReaderAuth, rootIaca: [])
+			secCerts: [leafCert], usage: .mdocReaderAuth, revocationPolicy: .hardFail, rootIaca: [])
 		#expect(!isValid)
 		#expect(rootCert == nil)
 		#expect(messages.contains(where: { $0.contains("not matched with root certificates") }))
@@ -74,7 +74,7 @@ struct CertificateHandlingTests {
 	func isMdocX5cValidSelfSignedRoot() throws {
 		let leafCert = try #require(eudiIaca.first)
 		// Use the same cert as a "root" — it is self-signed
-		let (isValid, messages, _) = SecurityHelpers.isMdocX5cValid(secCerts: [leafCert], usage: .mdocReaderAuth, rootIaca: [eudiIaca])
+		let (isValid, messages, _) = SecurityHelpers.isMdocX5cValid(secCerts: [leafCert], usage: .mdocReaderAuth, revocationPolicy: .hardFail, rootIaca: [eudiIaca])
 		// The cert is self signed
 		#expect(isValid)
 		print("Messages:", messages)
@@ -92,7 +92,7 @@ struct CertificateHandlingTests {
 	func isMdocX5cValidParameterized(testCase: X5cValidationTestCase) async throws {
 		let leafCerts = testCase.leafPEMs.compactMap { Self.secCertificate(fromPEM: $0) }
 		let (isValid, messages, _) = SecurityHelpers.isMdocX5cValid(
-			secCerts: leafCerts, usage: testCase.usage, rootIaca: [eudiIaca])
+			secCerts: leafCerts, usage: testCase.usage, revocationPolicy: .hardFail, rootIaca: [eudiIaca])
 		#expect(isValid == testCase.expectedValid, "Test '\(testCase.name)' expected isValid=\(testCase.expectedValid), got \(isValid). Messages: \(messages)")
 		print("Test '\(testCase.name)' messages:", messages)
 		let (isValid2, messages2, _) = await SecurityHelpers.isChainFound(secCerts: leafCerts, rootIaca: [eudiIaca])

--- a/Tests/MdocSecurity18013Tests/MdocSecurity18013Tests.swift
+++ b/Tests/MdocSecurity18013Tests/MdocSecurity18013Tests.swift
@@ -116,7 +116,7 @@ struct MdocSecurity18013Tests {
 		for docR in dr.docRequests {
 			let mdocAuth = MdocReaderAuthentication(transcript: sessionEncr.sessionTranscript)
 			guard let readerAuthRawCBOR = docR.readerAuthRawCBOR else { continue }
-			let (b, message) = try mdocAuth.validateReaderAuth(readerAuthCBOR: readerAuthRawCBOR, readerAuthX5c: docR.readerCertificates, itemsRequestRawData: docR.itemsRequestRawData!, rootIaca: [])
+            let (b, message) = try mdocAuth.validateReaderAuth(readerAuthCBOR: readerAuthRawCBOR, readerAuthX5c: docR.readerCertificates, itemsRequestRawData: docR.itemsRequestRawData!, rootIaca: [], crlRevocationPolicy: .hardFail)
 			#expect(!b, "Current date not in validity period of Certificate")
             print(message ?? "")
 		}
@@ -131,7 +131,7 @@ struct MdocSecurity18013Tests {
 		for docR in dr.docRequests {
 			let mdocAuth = MdocReaderAuthentication(transcript: sessionEncr.sessionTranscript)
 			guard let readerAuthRawCBOR = docR.readerAuthRawCBOR else { continue }
-			let (b, message) = try mdocAuth.validateReaderAuth(readerAuthCBOR: readerAuthRawCBOR, readerAuthX5c: docR.readerCertificates, itemsRequestRawData: docR.itemsRequestRawData!, rootIaca: rootIaca)
+			let (b, message) = try mdocAuth.validateReaderAuth(readerAuthCBOR: readerAuthRawCBOR, readerAuthX5c: docR.readerCertificates, itemsRequestRawData: docR.itemsRequestRawData!, rootIaca: rootIaca, crlRevocationPolicy: .hardFail)
 			#expect(!b, "Current date not in validity period of Certificate")
             print(message ?? "")
 		}


### PR DESCRIPTION
Enhance CRL revocation handling by introducing a RevocationPolicy enum and updating relevant authentication methods and tests to utilize this new parameter. This change improves the flexibility of revocation checks during certificate validation.

Fixes #97